### PR TITLE
Add asset and customer_asset removal to remove_entity

### DIFF
--- a/.claude/rules/adloop.md
+++ b/.claude/rules/adloop.md
@@ -80,7 +80,7 @@ These tools call both APIs internally and return unified results with computed `
 | `add_negative_keywords` | Propose negative keywords (does NOT add) | `campaign_id`, keyword list, `match_type` |
 | `pause_entity` | Propose pausing campaign/ad group/ad/keyword | `entity_type`, `entity_id` |
 | `enable_entity` | Propose enabling paused entity | `entity_type`, `entity_id` |
-| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "campaign_asset"), `entity_id` |
+| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "campaign_asset", "asset", "customer_asset"), `entity_id` |
 | `confirm_and_apply` | Execute a previously previewed change | `plan_id` from a draft tool, `dry_run` (default true) |
 
 **Write tool workflow:**
@@ -95,7 +95,7 @@ These tools call both APIs internally and return unified results with computed `
 - `draft_campaign` enforces the `max_daily_budget` safety cap, rejects BROAD match + non-Smart Bidding, and warns if budget is below 5x target CPA.
 - `update_campaign` replaces geo/language targets entirely (not append). Pass the full desired list.
 - `remove_entity` is IRREVERSIBLE — always prefer `pause_entity` unless the user explicitly wants permanent removal. Removal triggers double confirmation in the safety layer.
-- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "campaign_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "campaign_asset" to remove sitelinks and other asset links from a campaign.
+- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "campaign_asset", "asset", "customer_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "campaign_asset" to remove sitelinks and other asset links from a campaign. Use "asset" to remove a standalone asset. Use "customer_asset" to remove a customer-level asset link.
 - `require_dry_run: true` in config overrides `dry_run=false` — the user must change the config to allow real mutations.
 - All operations (including dry runs) are logged to `~/.adloop/audit.log`.
 

--- a/.cursor/rules/adloop.mdc
+++ b/.cursor/rules/adloop.mdc
@@ -85,7 +85,7 @@ These tools call both APIs internally and return unified results with computed `
 | `add_negative_keywords` | Propose negative keywords (does NOT add) | `campaign_id`, keyword list, `match_type` |
 | `pause_entity` | Propose pausing campaign/ad group/ad/keyword | `entity_type`, `entity_id` |
 | `enable_entity` | Propose enabling paused entity | `entity_type`, `entity_id` |
-| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "campaign_asset"), `entity_id` |
+| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "campaign_asset", "asset", "customer_asset"), `entity_id` |
 | `confirm_and_apply` | Execute a previously previewed change | `plan_id` from a draft tool, `dry_run` (default true) |
 
 **Write tool workflow:**
@@ -100,7 +100,7 @@ These tools call both APIs internally and return unified results with computed `
 - `draft_campaign` enforces the `max_daily_budget` safety cap, rejects BROAD match + non-Smart Bidding, and warns if budget is below 5x target CPA.
 - `update_campaign` replaces geo/language targets entirely (not append). Pass the full desired list.
 - `remove_entity` is IRREVERSIBLE — always prefer `pause_entity` unless the user explicitly wants permanent removal. Removal triggers double confirmation in the safety layer.
-- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "campaign_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "campaign_asset" to remove sitelinks and other asset links from a campaign.
+- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "campaign_asset", "asset", "customer_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "campaign_asset" to remove sitelinks and other asset links from a campaign. Use "asset" to remove a standalone asset. Use "customer_asset" to remove a customer-level asset link.
 - `require_dry_run: true` in config overrides `dry_run=false` — the user must change the config to allow real mutations.
 - All operations (including dry runs) are logged to `~/.adloop/audit.log`.
 

--- a/src/adloop/ads/write.py
+++ b/src/adloop/ads/write.py
@@ -275,8 +275,8 @@ def remove_entity(
     if errors:
         return {"error": "Validation failed", "details": errors}
 
-    # Normalize campaign_asset IDs: commas → tildes
-    if entity_type == "campaign_asset":
+    # Normalize composite IDs: commas → tildes
+    if entity_type in ("campaign_asset", "customer_asset"):
         entity_id = entity_id.replace(",", "~")
 
     plan = ChangePlan(
@@ -680,7 +680,9 @@ def confirm_and_apply(
 
 _VALID_MATCH_TYPES = {"EXACT", "PHRASE", "BROAD"}
 _VALID_ENTITY_TYPES = {"campaign", "ad_group", "ad", "keyword"}
-_REMOVABLE_ENTITY_TYPES = _VALID_ENTITY_TYPES | {"negative_keyword", "campaign_asset"}
+_REMOVABLE_ENTITY_TYPES = _VALID_ENTITY_TYPES | {
+    "negative_keyword", "campaign_asset", "asset", "customer_asset",
+}
 
 _SMART_BIDDING_STRATEGIES = {
     "MAXIMIZE_CONVERSIONS",
@@ -1415,6 +1417,34 @@ def _apply_remove(
         resp_inner = response.mutate_operation_responses[0]
         if resp_inner.campaign_asset_result.resource_name:
             return {"resource_name": resp_inner.campaign_asset_result.resource_name}
+        return {"resource_name": resource_name, "status": "removed"}
+
+    elif entity_type == "asset":
+        service = client.get_service("AssetService")
+        operation = client.get_type("AssetOperation")
+        operation.remove = service.asset_path(cid, entity_id)
+        response = service.mutate_assets(
+            customer_id=cid, operations=[operation]
+        )
+
+    elif entity_type == "customer_asset":
+        parts = entity_id.replace(",", "~").split("~")
+        if len(parts) != 2:
+            raise ValueError(
+                f"customer_asset entity_id must be "
+                f"'assetId~fieldType', got '{entity_id}'"
+            )
+        ca_service = client.get_service("CustomerAssetService")
+        resource_name = ca_service.customer_asset_path(cid, parts[0], parts[1])
+        ga_service = client.get_service("GoogleAdsService")
+        op = client.get_type("MutateOperation")
+        op.customer_asset_operation.remove = resource_name
+        response = ga_service.mutate(
+            customer_id=cid, mutate_operations=[op]
+        )
+        resp_inner = response.mutate_operation_responses[0]
+        if resp_inner.customer_asset_result.resource_name:
+            return {"resource_name": resp_inner.customer_asset_result.resource_name}
         return {"resource_name": resource_name, "status": "removed"}
 
     else:

--- a/src/adloop/server.py
+++ b/src/adloop/server.py
@@ -693,9 +693,14 @@ def remove_entity(
 ) -> dict:
     """Draft REMOVING an entity — returns a PREVIEW. This is IRREVERSIBLE.
 
-    entity_type: "campaign", "ad_group", "ad", "keyword", or "negative_keyword"
-    entity_id: The resource ID. For keywords use "adGroupId~criterionId".
-               For negative_keywords use the campaign criterion ID.
+    entity_type: "campaign", "ad_group", "ad", "keyword", "negative_keyword",
+                 "campaign_asset", "asset", or "customer_asset"
+    entity_id: The resource ID.
+               For keywords: "adGroupId~criterionId"
+               For negative_keywords: the campaign criterion ID
+               For campaign_asset: "campaignId~assetId~fieldType"
+               For asset: simple asset ID
+               For customer_asset: "assetId~fieldType"
 
     WARNING: Removed entities cannot be re-enabled. Use pause_entity instead
     if you just want to temporarily disable something.


### PR DESCRIPTION
## Summary
- Extend `remove_entity` to support two new entity types: `asset` (standalone assets via `AssetService`) and `customer_asset` (customer-level asset links via `CustomerAssetService`)
- Update ID normalization to handle `customer_asset` composite IDs (`assetId~fieldType`)
- Update docstrings and orchestration rules in both `.claude/rules/` and `.cursor/rules/`

## Test plan
- [x] `uv run pytest` — all 14 existing tests pass
- [x] Manual: `remove_entity(entity_type="asset", entity_id="INVALID")` → returns preview
- [x] Manual: `remove_entity(entity_type="customer_asset", entity_id="123~SITELINK")` → returns preview
- [x] Manual: `remove_entity(entity_type="bogus", ...)` → validation error listing all 8 types

🤖 Generated with [Claude Code](https://claude.com/claude-code)