### PR TITLE
Add propose_negative_keyword_list tool using SharedSet API

### DIFF
--- a/.claude/rules/adloop.md
+++ b/.claude/rules/adloop.md
@@ -79,6 +79,7 @@ These tools call both APIs internally and return unified results with computed `
 
 | Tool | When to Use | Key Parameters |
 |------|-------------|----------------|
+| `discover_keywords` | Discover new keyword ideas from seed keywords and/or a URL — returns avg monthly searches, competition, and bid range | `seed_keywords` (list, optional), `url` (optional), `geo_target_id`, `language_id`, `page_size` |
 | `estimate_budget` | Budget planning before launching a campaign — forecasts clicks, impressions, cost for a set of keywords | `keywords` (list of {text, match_type, max_cpc}), `daily_budget` (optional), `geo_target_id`, `language_id`, `forecast_days` |
 
 `estimate_budget` calls the Google Ads Keyword Planner API (read-only — creates nothing). Returns forecast metrics for the specified keywords and optional budget, including daily estimates and insights about budget sufficiency. Common geo targets: 2276=Germany, 2840=USA, 2826=UK. Common languages: 1000=English, 1001=German, 1002=French.
@@ -260,6 +261,17 @@ Most websites (especially in the EU) use a GDPR cookie consent banner. This has 
 4. Call `update_campaign` with only the parameters that need to change
 5. Present the preview — clearly show what's changing (old → new)
 6. Wait for explicit user approval before calling `confirm_and_apply`
+
+### When user wants to discover new keywords
+
+1. Ask whether to start with seed keywords, a URL, or both — these map directly to the two modes in Google Ads Keyword Planner UI
+2. Call `discover_keywords` with `seed_keywords`, `url`, or both, plus the target `geo_target_id` and `language_id`
+3. Review `insights[]` — highlights the highest-volume idea, high-competition terms to budget carefully for, and low-competition opportunities
+4. Present results grouped by competition level (LOW → MEDIUM → HIGH) so the user can quickly spot easy wins vs expensive battles
+5. For any ideas the user wants to act on, suggest the next step:
+   - Use `estimate_budget` with the selected keywords to forecast traffic and cost before committing
+   - Use `draft_keywords` to add them to an existing ad group
+   - Use `draft_campaign` to build a new campaign around them
 
 ### When user asks "how much should I spend" or "what budget do I need"
 

--- a/.claude/rules/adloop.md
+++ b/.claude/rules/adloop.md
@@ -34,7 +34,10 @@ You have access to AdLoop MCP tools that connect Google Ads and Google Analytics
 | `get_ad_performance` | Ad copy analysis — which headlines/descriptions work | `date_range_start`, `date_range_end` |
 | `get_keyword_performance` | Keyword analysis — quality scores, competitive metrics | `date_range_start`, `date_range_end` |
 | `get_search_terms` | Find negative keyword opportunities and understand user intent | `date_range_start`, `date_range_end` |
-| `get_negative_keywords` | List existing negative keywords for a campaign or all campaigns | `campaign_id` (optional) |
+| `get_negative_keywords` | List direct campaign-level negative keywords (not inside SharedSets) | `campaign_id` (optional) |
+| `get_negative_keyword_lists` | List all shared negative keyword lists — names, IDs, status, keyword count | (none) |
+| `get_negative_keyword_list_keywords` | List the keywords inside a specific shared negative keyword list | `shared_set_id` (required) |
+| `get_negative_keyword_list_campaigns` | List which campaigns a shared negative keyword list is attached to | `shared_set_id` (optional) |
 | `get_recommendations` | Google's auto-generated recommendations with estimated impact — budget, keyword, bid strategy, ad copy suggestions | `recommendation_types` (optional filter), `campaign_id` (optional) |
 | `get_pmax_performance` | Performance Max campaign metrics with network breakdown + asset group ad strength | `date_range_start`, `date_range_end` |
 | `get_asset_performance` | Per-asset details for PMax — field type, serving status, content. Use with `get_detailed_asset_performance` for quality signals | `campaign_id` (optional) |
@@ -284,7 +287,8 @@ Most websites (especially in the EU) use a GDPR cookie consent banner. This has 
 5. Choose the right write tool:
    - **Direct campaign negatives** (`add_negative_keywords`): faster, campaign-specific, no reuse across campaigns
    - **Shared negative keyword list** (`propose_negative_keyword_list`): creates a named, reusable list that can be attached to multiple campaigns — prefer this when the user wants to reuse the list or when they explicitly mention "list"
-6. Present preview and wait for confirmation
+6. **Before calling `propose_negative_keyword_list`**, always call `get_negative_keyword_lists` first to check whether a suitable list already exists. If a matching list is found, inspect its keywords via `get_negative_keyword_list_keywords` and check which campaigns it is already on via `get_negative_keyword_list_campaigns` — it may only need attaching to a new campaign rather than being recreated. Creating duplicate lists wastes account resources and makes management harder.
+7. Present preview and wait for confirmation
 
 ### When user asks to pause or enable something
 

--- a/.claude/rules/adloop.md
+++ b/.claude/rules/adloop.md
@@ -94,7 +94,8 @@ These tools call both APIs internally and return unified results with computed `
 | `draft_image_assets` | Create image assets for a campaign from local files (does NOT publish) | `campaign_id`, `image_paths` list of local PNG/JPEG/GIF files |
 | `draft_sitelinks` | Create sitelink extensions for a campaign (does NOT publish) | `campaign_id`, `sitelinks` list of {link_text ≤25 chars, final_url, description1 ≤35 chars, description2 ≤35 chars} |
 | `draft_keywords` | Propose keyword additions (does NOT add) | Each keyword needs `text` and `match_type` (EXACT/PHRASE/BROAD) |
-| `add_negative_keywords` | Propose negative keywords (does NOT add) | `campaign_id`, keyword list, `match_type` |
+| `add_negative_keywords` | Propose negative keywords directly on a campaign (does NOT add) | `campaign_id`, keyword list, `match_type` |
+| `propose_negative_keyword_list` | Draft a shared negative keyword list and attach it to a campaign (does NOT create) | `campaign_id`, `list_name`, keyword list, `match_type` |
 | `pause_entity` | Propose pausing campaign/ad group/ad/keyword | `entity_type`, `entity_id` |
 | `enable_entity` | Propose enabling paused entity | `entity_type`, `entity_id` |
 | `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "campaign_asset", "asset", "customer_asset"), `entity_id` |
@@ -280,7 +281,9 @@ Most websites (especially in the EU) use a GDPR cookie consent banner. This has 
 2. Call `get_negative_keywords` to see what's already blocked — avoid duplicates
 3. Identify irrelevant terms that waste budget — group them by theme
 4. Call `get_campaign_performance` to get the right `campaign.id`
-5. Call `add_negative_keywords` with the proposed list and the campaign ID
+5. Choose the right write tool:
+   - **Direct campaign negatives** (`add_negative_keywords`): faster, campaign-specific, no reuse across campaigns
+   - **Shared negative keyword list** (`propose_negative_keyword_list`): creates a named, reusable list that can be attached to multiple campaigns — prefer this when the user wants to reuse the list or when they explicitly mention "list"
 6. Present preview and wait for confirmation
 
 ### When user asks to pause or enable something

--- a/src/adloop/ads/client.py
+++ b/src/adloop/ads/client.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import random
+import time
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+_T = TypeVar("_T")
 
 if TYPE_CHECKING:
     from google.ads.googleads.client import GoogleAdsClient
@@ -39,3 +43,40 @@ def get_ads_client(config: AdLoopConfig) -> GoogleAdsClient:
 def normalize_customer_id(customer_id: str) -> str:
     """Strip dashes from customer ID for API calls (123-456-7890 -> 1234567890)."""
     return customer_id.replace("-", "")
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """Return True if the exception is a 429 / RESOURCE_EXHAUSTED rate-limit error."""
+    msg = str(exc).upper()
+    return (
+        "RESOURCE_EXHAUSTED" in msg
+        or "429" in msg
+        or "RATE_LIMIT" in msg
+        or "QUOTA_EXCEEDED" in msg
+    )
+
+
+def call_with_retry(
+    fn: Callable[..., _T],
+    /,
+    *args: Any,
+    max_attempts: int = 4,
+    base_delay: float = 1.0,
+    **kwargs: Any,
+) -> _T:
+    """Call fn(*args, **kwargs) with exponential backoff on 429 / RESOURCE_EXHAUSTED.
+
+    Retries up to max_attempts times (default 4 — i.e. 3 retries after the
+    initial attempt). Each wait is base_delay * 2^attempt seconds plus up to
+    1 second of random jitter to avoid thundering-herd.
+
+    All other exceptions are re-raised immediately without retrying.
+    """
+    for attempt in range(max_attempts):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if not _is_rate_limit_error(exc) or attempt == max_attempts - 1:
+                raise
+            delay = base_delay * (2**attempt) + random.uniform(0, 1)
+            time.sleep(delay)

--- a/src/adloop/ads/forecast.py
+++ b/src/adloop/ads/forecast.py
@@ -1,4 +1,4 @@
-"""Budget estimation via Google Ads Keyword Planner forecast metrics."""
+"""Budget estimation and keyword discovery via Google Ads Keyword Planner."""
 
 from __future__ import annotations
 
@@ -152,5 +152,119 @@ def estimate_budget(
         "estimated_ctr": round(ctr, 4) if ctr else None,
         "daily_estimates": daily,
         "keywords_used": len([kw for kw in keywords if kw.get("text")]),
+        "insights": insights,
+    }
+
+
+_COMPETITION_LABELS = {0: "UNSPECIFIED", 1: "LOW", 2: "MEDIUM", 3: "HIGH"}
+
+
+def discover_keywords(
+    config: AdLoopConfig,
+    *,
+    seed_keywords: list[str] | None = None,
+    url: str = "",
+    geo_target_id: str = "2276",
+    language_id: str = "1000",
+    page_size: int = 50,
+    customer_id: str = "",
+) -> dict:
+    """Discover new keyword ideas using Google Ads Keyword Planner.
+
+    Mirrors the "Discover new keywords" workflow in the Keyword Planner UI:
+    - Start with keywords: provide seed_keywords (one or more terms)
+    - Start with a website: provide url (a landing page or full site URL)
+    - Both together: keywords + url for more targeted ideas
+
+    Returns keyword ideas with avg monthly searches, competition level,
+    and top-of-page bid range.
+
+    seed_keywords: list of seed terms, e.g. ["running shoes", "trail running"]
+    url: a page or site URL to extract keyword ideas from
+    geo_target_id: geo target constant (2276=Germany, 2840=USA, 2826=UK)
+    language_id: language constant (1000=English, 1001=German, 1002=French)
+    page_size: max number of keyword ideas to return (default 50, max 1000)
+    """
+    from adloop.ads.client import get_ads_client, normalize_customer_id
+
+    seed_keywords = seed_keywords or []
+    if not seed_keywords and not url:
+        return {"error": "Provide at least one of: seed_keywords or url"}
+
+    client = get_ads_client(config)
+    cid = normalize_customer_id(customer_id or config.ads.customer_id)
+    googleads_service = client.get_service("GoogleAdsService")
+    kp_service = client.get_service("KeywordPlanIdeaService")
+
+    request = client.get_type("GenerateKeywordIdeasRequest")
+    request.customer_id = cid
+    request.language = googleads_service.language_constant_path(language_id)
+    request.geo_target_constants.append(
+        googleads_service.geo_target_constant_path(geo_target_id)
+    )
+    request.keyword_plan_network = (
+        client.enums.KeywordPlanNetworkEnum.GOOGLE_SEARCH
+    )
+    request.page_size = min(max(1, page_size), 1000)
+
+    if seed_keywords and url:
+        request.keyword_and_url_seed.url = url
+        request.keyword_and_url_seed.keywords.extend(seed_keywords)
+    elif seed_keywords:
+        request.keyword_seed.keywords.extend(seed_keywords)
+    else:
+        request.url_seed.url = url
+
+    response = kp_service.generate_keyword_ideas(request=request)
+
+    ideas = []
+    for idea in response:
+        metrics = idea.keyword_idea_metrics
+        avg_monthly = getattr(metrics, "avg_monthly_searches", None)
+        competition_value = getattr(metrics, "competition", 0)
+        competition_label = _COMPETITION_LABELS.get(int(competition_value), "UNSPECIFIED")
+        competition_index = getattr(metrics, "competition_index", None)
+        low_bid_micros = getattr(metrics, "low_top_of_page_bid_micros", None)
+        high_bid_micros = getattr(metrics, "high_top_of_page_bid_micros", None)
+
+        ideas.append({
+            "keyword": idea.text,
+            "avg_monthly_searches": int(avg_monthly) if avg_monthly else None,
+            "competition": competition_label,
+            "competition_index": int(competition_index) if competition_index else None,
+            "low_top_of_page_bid": round(low_bid_micros / 1_000_000, 2) if low_bid_micros else None,
+            "high_top_of_page_bid": round(high_bid_micros / 1_000_000, 2) if high_bid_micros else None,
+        })
+
+    # Sort by avg monthly searches descending (None last)
+    ideas.sort(key=lambda x: x["avg_monthly_searches"] or 0, reverse=True)
+
+    insights = []
+    if ideas:
+        high_competition = [i for i in ideas if i["competition"] == "HIGH"]
+        low_competition = [i for i in ideas if i["competition"] == "LOW"]
+        if high_competition:
+            insights.append(
+                f"{len(high_competition)} high-competition keyword(s) — expect "
+                f"higher CPCs and harder positioning."
+            )
+        if low_competition:
+            insights.append(
+                f"{len(low_competition)} low-competition keyword(s) — good "
+                f"opportunities for early traction at lower cost."
+            )
+        with_volume = [i for i in ideas if i["avg_monthly_searches"]]
+        if with_volume:
+            top = with_volume[0]
+            insights.append(
+                f"Highest-volume idea: '{top['keyword']}' with ~{top['avg_monthly_searches']:,} "
+                f"avg monthly searches."
+            )
+
+    return {
+        "keyword_ideas": ideas,
+        "total_ideas": len(ideas),
+        "seed_keywords": seed_keywords,
+        "seed_url": url,
         "insights": insights,
     }

--- a/src/adloop/ads/forecast.py
+++ b/src/adloop/ads/forecast.py
@@ -162,7 +162,7 @@ _COMPETITION_LABELS = {0: "UNSPECIFIED", 1: "LOW", 2: "MEDIUM", 3: "HIGH"}
 def discover_keywords(
     config: AdLoopConfig,
     *,
-    seed_keywords: list[str] | None = None,
+    seed_keywords: list[str] = [],
     url: str = "",
     geo_target_id: str = "2276",
     language_id: str = "1000",
@@ -185,7 +185,7 @@ def discover_keywords(
     language_id: language constant (1000=English, 1001=German, 1002=French)
     page_size: max number of keyword ideas to return (default 50, max 1000)
     """
-    from adloop.ads.client import get_ads_client, normalize_customer_id
+    from adloop.ads.client import call_with_retry, get_ads_client, normalize_customer_id
 
     seed_keywords = seed_keywords or []
     if not seed_keywords and not url:
@@ -215,7 +215,7 @@ def discover_keywords(
     else:
         request.url_seed.url = url
 
-    response = kp_service.generate_keyword_ideas(request=request)
+    response = call_with_retry(kp_service.generate_keyword_ideas, request=request)
 
     ideas = []
     for idea in response:

--- a/src/adloop/ads/read.py
+++ b/src/adloop/ads/read.py
@@ -222,6 +222,96 @@ def get_negative_keywords(
     return {"negative_keywords": rows, "total_negative_keywords": len(rows)}
 
 
+def get_negative_keyword_lists(
+    config: AdLoopConfig,
+    *,
+    customer_id: str = "",
+) -> dict:
+    """List all shared negative keyword lists (SharedSets) in the account.
+
+    Returns each list's ID, name, status, and keyword count. Use this before
+    calling propose_negative_keyword_list to check whether a suitable list
+    already exists and only needs attaching to a new campaign.
+    """
+    from adloop.ads.gaql import execute_query
+
+    query = """
+        SELECT shared_set.id, shared_set.name, shared_set.status,
+               shared_set.member_count, shared_set.resource_name
+        FROM shared_set
+        WHERE shared_set.type = 'NEGATIVE_KEYWORDS'
+          AND shared_set.status != 'REMOVED'
+        ORDER BY shared_set.name
+    """
+
+    rows = execute_query(config, customer_id, query)
+    return {"negative_keyword_lists": rows, "total_lists": len(rows)}
+
+
+def get_negative_keyword_list_keywords(
+    config: AdLoopConfig,
+    *,
+    customer_id: str = "",
+    shared_set_id: str = "",
+) -> dict:
+    """List the keywords inside a shared negative keyword list.
+
+    shared_set_id: the numeric ID from get_negative_keyword_lists
+    (shared_set.id field).
+    """
+    from adloop.ads.gaql import execute_query
+
+    if not shared_set_id:
+        return {"error": "shared_set_id is required"}
+
+    query = f"""
+        SELECT shared_criterion.keyword.text,
+               shared_criterion.keyword.match_type,
+               shared_criterion.type,
+               shared_set.id, shared_set.name
+        FROM shared_criterion
+        WHERE shared_set.id = {shared_set_id}
+        ORDER BY shared_criterion.keyword.text
+    """
+
+    rows = execute_query(config, customer_id, query)
+    return {
+        "keywords": rows,
+        "total_keywords": len(rows),
+        "shared_set_id": shared_set_id,
+    }
+
+
+def get_negative_keyword_list_campaigns(
+    config: AdLoopConfig,
+    *,
+    customer_id: str = "",
+    shared_set_id: str = "",
+) -> dict:
+    """List which campaigns a shared negative keyword list is attached to.
+
+    shared_set_id: the numeric ID from get_negative_keyword_lists
+    (shared_set.id field). Omit to return all list-to-campaign attachments.
+    """
+    from adloop.ads.gaql import execute_query
+
+    shared_set_filter = ""
+    if shared_set_id:
+        shared_set_filter = f"AND shared_set.id = {shared_set_id}"
+
+    query = f"""
+        SELECT campaign.id, campaign.name, campaign.status,
+               shared_set.id, shared_set.name
+        FROM campaign_shared_set
+        WHERE campaign_shared_set.status != 'REMOVED'
+          {shared_set_filter}
+        ORDER BY shared_set.name, campaign.name
+    """
+
+    rows = execute_query(config, customer_id, query)
+    return {"attachments": rows, "total_attachments": len(rows)}
+
+
 def get_recommendations(
     config: AdLoopConfig,
     *,

--- a/src/adloop/ads/write.py
+++ b/src/adloop/ads/write.py
@@ -341,6 +341,61 @@ def add_negative_keywords(
     return plan.to_preview()
 
 
+def propose_negative_keyword_list(
+    config: AdLoopConfig,
+    *,
+    customer_id: str = "",
+    campaign_id: str = "",
+    list_name: str = "",
+    keywords: list[str] | None = None,
+    match_type: str = "EXACT",
+) -> dict:
+    """Draft a shared negative keyword list and attach it to a campaign — returns PREVIEW.
+
+    Creates a reusable negative keyword list (SharedSet) with the given keywords
+    and links it to the campaign. Unlike add_negative_keywords, the list can later
+    be reused across multiple campaigns.
+    Call confirm_and_apply with the returned plan_id to execute.
+    """
+    from adloop.safety.guards import SafetyViolation, check_blocked_operation
+    from adloop.safety.preview import ChangePlan, store_plan
+
+    try:
+        check_blocked_operation("add_negative_keywords", config.safety)
+    except SafetyViolation as e:
+        return {"error": str(e)}
+
+    keywords = keywords or []
+    match_type = match_type.upper()
+
+    errors = []
+    if not campaign_id:
+        errors.append("campaign_id is required")
+    if not list_name:
+        errors.append("list_name is required")
+    if not keywords:
+        errors.append("At least one keyword is required")
+    if match_type not in _VALID_MATCH_TYPES:
+        errors.append(f"Invalid match_type '{match_type}' — use EXACT, PHRASE, or BROAD")
+    if errors:
+        return {"error": "Validation failed", "details": errors}
+
+    plan = ChangePlan(
+        operation="create_negative_keyword_list",
+        entity_type="negative_keyword_list",
+        entity_id=campaign_id,
+        customer_id=customer_id,
+        changes={
+            "campaign_id": campaign_id,
+            "list_name": list_name,
+            "keywords": keywords,
+            "match_type": match_type,
+        },
+    )
+    store_plan(plan)
+    return plan.to_preview()
+
+
 def update_ad_group(
     config: AdLoopConfig,
     *,
@@ -1670,6 +1725,7 @@ def _execute_plan(config: AdLoopConfig, plan: object) -> dict:
         "create_responsive_search_ad": _apply_create_rsa,
         "add_keywords": _apply_add_keywords,
         "add_negative_keywords": _apply_add_negative_keywords,
+        "create_negative_keyword_list": _apply_create_negative_keyword_list,
         "pause_entity": _apply_status_change,
         "enable_entity": _apply_status_change,
         "remove_entity": _apply_remove,
@@ -2462,3 +2518,57 @@ def _apply_create_sitelinks(client: object, cid: str, changes: dict) -> dict:
         client.enums.AssetFieldTypeEnum.SITELINK,
         populate,
     )
+
+
+def _apply_create_negative_keyword_list(
+    client: object, cid: str, changes: dict
+) -> dict:
+    """Create a shared negative keyword list and attach it to a campaign.
+
+    Executes three sequential API calls:
+    1. SharedSetService — create the named list
+    2. SharedCriterionService — add keywords to it
+    3. CampaignSharedSetService — attach the list to the campaign
+    """
+    # 1. Create the SharedSet
+    shared_set_service = client.get_service("SharedSetService")
+    ss_op = client.get_type("SharedSetOperation")
+    shared_set = ss_op.create
+    shared_set.name = changes["list_name"]
+    shared_set.type_ = client.enums.SharedSetTypeEnum.NEGATIVE_KEYWORDS
+    ss_response = shared_set_service.mutate_shared_sets(
+        customer_id=cid, operations=[ss_op]
+    )
+    shared_set_resource = ss_response.results[0].resource_name
+
+    # 2. Add keywords to the list
+    sc_service = client.get_service("SharedCriterionService")
+    sc_ops = []
+    for kw_text in changes["keywords"]:
+        sc_op = client.get_type("SharedCriterionOperation")
+        criterion = sc_op.create
+        criterion.shared_set = shared_set_resource
+        criterion.keyword.text = kw_text
+        criterion.keyword.match_type = getattr(
+            client.enums.KeywordMatchTypeEnum, changes["match_type"]
+        )
+        sc_ops.append(sc_op)
+    sc_service.mutate_shared_criteria(customer_id=cid, operations=sc_ops)
+
+    # 3. Attach the list to the campaign
+    css_service = client.get_service("CampaignSharedSetService")
+    css_op = client.get_type("CampaignSharedSetOperation")
+    campaign_shared_set = css_op.create
+    campaign_shared_set.campaign = client.get_service("CampaignService").campaign_path(
+        cid, changes["campaign_id"]
+    )
+    campaign_shared_set.shared_set = shared_set_resource
+    css_response = css_service.mutate_campaign_shared_sets(
+        customer_id=cid, operations=[css_op]
+    )
+
+    return {
+        "shared_set_resource": shared_set_resource,
+        "campaign_shared_set_resource": css_response.results[0].resource_name,
+        "keyword_count": len(changes["keywords"]),
+    }

--- a/src/adloop/server.py
+++ b/src/adloop/server.py
@@ -1295,3 +1295,40 @@ def estimate_budget(
         forecast_days=forecast_days,
         customer_id=customer_id or _config.ads.customer_id,
     )
+
+
+@mcp.tool(annotations=_READONLY)
+@_safe
+def discover_keywords(
+    seed_keywords: list[str] | None = None,
+    url: str = "",
+    geo_target_id: str = "2276",
+    language_id: str = "1000",
+    page_size: int = 50,
+    customer_id: str = "",
+) -> dict:
+    """Discover new keyword ideas using Google Ads Keyword Planner.
+
+    Mirrors the "Discover new keywords" UI in Keyword Planner:
+    - Start with keywords: pass seed_keywords (e.g. ["running shoes"])
+    - Start with a website: pass url (e.g. "https://example.com/products")
+    - Both together: keywords + url for more targeted ideas
+
+    Returns keyword ideas sorted by avg monthly search volume, with
+    competition level (LOW/MEDIUM/HIGH) and top-of-page bid range.
+
+    geo_target_id: geo target constant (2276=Germany, 2840=USA, 2826=UK)
+    language_id: language constant (1000=English, 1001=German, 1002=French)
+    page_size: max keyword ideas to return (default 50, max 1000)
+    """
+    from adloop.ads.forecast import discover_keywords as _impl
+
+    return _impl(
+        _config,
+        seed_keywords=seed_keywords,
+        url=url,
+        geo_target_id=geo_target_id,
+        language_id=language_id,
+        page_size=page_size,
+        customer_id=customer_id or _config.ads.customer_id,
+    )

--- a/src/adloop/server.py
+++ b/src/adloop/server.py
@@ -1300,7 +1300,7 @@ def estimate_budget(
 @mcp.tool(annotations=_READONLY)
 @_safe
 def discover_keywords(
-    seed_keywords: list[str] | None = None,
+    seed_keywords: list[str] = [],
     url: str = "",
     geo_target_id: str = "2276",
     language_id: str = "1000",

--- a/src/adloop/server.py
+++ b/src/adloop/server.py
@@ -393,6 +393,61 @@ def get_negative_keywords(
     )
 
 
+@mcp.tool(annotations=_READONLY)
+@_safe
+def get_negative_keyword_lists(
+    customer_id: str = "",
+) -> dict:
+    """List all shared negative keyword lists (SharedSets) in the account.
+
+    Returns each list's ID, name, status, and keyword count. Always call
+    this before propose_negative_keyword_list to avoid creating duplicates —
+    a suitable list may already exist and just need attaching to a campaign.
+    """
+    from adloop.ads.read import get_negative_keyword_lists as _impl
+
+    return _impl(_config, customer_id=customer_id or _config.ads.customer_id)
+
+
+@mcp.tool(annotations=_READONLY)
+@_safe
+def get_negative_keyword_list_keywords(
+    shared_set_id: str,
+    customer_id: str = "",
+) -> dict:
+    """List the keywords inside a shared negative keyword list.
+
+    shared_set_id: numeric ID from get_negative_keyword_lists (shared_set.id).
+    """
+    from adloop.ads.read import get_negative_keyword_list_keywords as _impl
+
+    return _impl(
+        _config,
+        customer_id=customer_id or _config.ads.customer_id,
+        shared_set_id=shared_set_id,
+    )
+
+
+@mcp.tool(annotations=_READONLY)
+@_safe
+def get_negative_keyword_list_campaigns(
+    shared_set_id: str = "",
+    customer_id: str = "",
+) -> dict:
+    """List which campaigns a shared negative keyword list is attached to.
+
+    shared_set_id: numeric ID from get_negative_keyword_lists. Omit to see
+    all list-to-campaign attachments across the account.
+    """
+    from adloop.ads.read import get_negative_keyword_list_campaigns as _impl
+
+    return _impl(
+        _config,
+        customer_id=customer_id or _config.ads.customer_id,
+        shared_set_id=shared_set_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Google Ads — Recommendations, Performance Max & Audience Tools
 # ---------------------------------------------------------------------------

--- a/src/adloop/server.py
+++ b/src/adloop/server.py
@@ -898,6 +898,34 @@ def add_negative_keywords(
 
 @mcp.tool(annotations=_WRITE)
 @_safe
+def propose_negative_keyword_list(
+    campaign_id: str,
+    list_name: str,
+    keywords: list[str],
+    customer_id: str = "",
+    match_type: str = "EXACT",
+) -> dict:
+    """Draft a shared negative keyword list and attach it to a campaign — returns a PREVIEW.
+
+    Creates a reusable negative keyword list that can later be applied to multiple
+    campaigns, unlike add_negative_keywords which adds directly to one campaign.
+    match_type: "EXACT", "PHRASE", or "BROAD"
+    Call confirm_and_apply with the returned plan_id to execute.
+    """
+    from adloop.ads.write import propose_negative_keyword_list as _impl
+
+    return _impl(
+        _config,
+        customer_id=customer_id or _config.ads.customer_id,
+        campaign_id=campaign_id,
+        list_name=list_name,
+        keywords=keywords,
+        match_type=match_type,
+    )
+
+
+@mcp.tool(annotations=_WRITE)
+@_safe
 def update_ad_group(
     ad_group_id: str,
     customer_id: str = "",

--- a/tests/test_ads_write.py
+++ b/tests/test_ads_write.py
@@ -9,7 +9,7 @@ import pytest
 from google.ads.googleads.client import GoogleAdsClient
 
 from adloop.ads.client import GOOGLE_ADS_API_VERSION
-from adloop.ads import write
+from adloop.ads import read, write
 from adloop.config import AdLoopConfig, AdsConfig, SafetyConfig
 from adloop.safety import preview as preview_store
 
@@ -681,6 +681,82 @@ class TestProposeNegativeKeywordList:
         plan_id = result["plan_id"]
         from adloop.safety import preview as preview_store
         assert plan_id in preview_store._pending_plans
+
+
+class TestGetNegativeKeywordLists:
+    def test_returns_list_of_shared_sets(self, config, monkeypatch):
+        fake_rows = [
+            {
+                "shared_set.id": "111",
+                "shared_set.name": "Brand Exclusions",
+                "shared_set.status": "ENABLED",
+                "shared_set.member_count": 5,
+                "shared_set.resource_name": "customers/123/sharedSets/111",
+            }
+        ]
+        monkeypatch.setattr(
+            "adloop.ads.gaql.execute_query", lambda *_a, **_kw: fake_rows
+        )
+        result = read.get_negative_keyword_lists(config, customer_id="123-456-7890")
+        assert result["total_lists"] == 1
+        assert result["negative_keyword_lists"][0]["shared_set.name"] == "Brand Exclusions"
+
+    def test_empty_account_returns_zero(self, config, monkeypatch):
+        monkeypatch.setattr("adloop.ads.gaql.execute_query", lambda *_a, **_kw: [])
+        result = read.get_negative_keyword_lists(config)
+        assert result["total_lists"] == 0
+        assert result["negative_keyword_lists"] == []
+
+
+class TestGetNegativeKeywordListKeywords:
+    def test_requires_shared_set_id(self, config):
+        result = read.get_negative_keyword_list_keywords(config)
+        assert result["error"] == "shared_set_id is required"
+
+    def test_returns_keywords_for_list(self, config, monkeypatch):
+        fake_rows = [
+            {
+                "shared_criterion.keyword.text": "free",
+                "shared_criterion.keyword.match_type": "EXACT",
+                "shared_set.id": "111",
+                "shared_set.name": "Brand Exclusions",
+            }
+        ]
+        monkeypatch.setattr(
+            "adloop.ads.gaql.execute_query", lambda *_a, **_kw: fake_rows
+        )
+        result = read.get_negative_keyword_list_keywords(
+            config, customer_id="123-456-7890", shared_set_id="111"
+        )
+        assert result["total_keywords"] == 1
+        assert result["shared_set_id"] == "111"
+        assert result["keywords"][0]["shared_criterion.keyword.text"] == "free"
+
+
+class TestGetNegativeKeywordListCampaigns:
+    def test_returns_attachments(self, config, monkeypatch):
+        fake_rows = [
+            {
+                "campaign.id": "1001",
+                "campaign.name": "Summer Sale",
+                "campaign.status": "ENABLED",
+                "shared_set.id": "111",
+                "shared_set.name": "Brand Exclusions",
+            }
+        ]
+        monkeypatch.setattr(
+            "adloop.ads.gaql.execute_query", lambda *_a, **_kw: fake_rows
+        )
+        result = read.get_negative_keyword_list_campaigns(
+            config, customer_id="123-456-7890", shared_set_id="111"
+        )
+        assert result["total_attachments"] == 1
+        assert result["attachments"][0]["campaign.name"] == "Summer Sale"
+
+    def test_no_shared_set_id_returns_all_attachments(self, config, monkeypatch):
+        monkeypatch.setattr("adloop.ads.gaql.execute_query", lambda *_a, **_kw: [])
+        result = read.get_negative_keyword_list_campaigns(config)
+        assert result["total_attachments"] == 0
 
 
 def test_extract_error_message_handles_plain_exceptions():

--- a/tests/test_ads_write.py
+++ b/tests/test_ads_write.py
@@ -601,6 +601,88 @@ def test_remove_entity_normalizes_commas_to_tildes(config):
     assert result["entity_id"] == "1001~99~SITELINK"
 
 
+class TestProposeNegativeKeywordList:
+    def test_returns_preview_with_correct_operation(self, config):
+        result = write.propose_negative_keyword_list(
+            config,
+            customer_id="123-456-7890",
+            campaign_id="1001",
+            list_name="Irrelevant Terms",
+            keywords=["free", "cheap diy"],
+            match_type="EXACT",
+        )
+        assert result["operation"] == "create_negative_keyword_list"
+        assert result["entity_type"] == "negative_keyword_list"
+        assert result["entity_id"] == "1001"
+        assert result["changes"]["list_name"] == "Irrelevant Terms"
+        assert result["changes"]["keywords"] == ["free", "cheap diy"]
+        assert result["changes"]["match_type"] == "EXACT"
+        assert result["status"] == "PENDING_CONFIRMATION"
+        assert "plan_id" in result
+
+    def test_normalises_match_type_to_uppercase(self, config):
+        result = write.propose_negative_keyword_list(
+            config,
+            customer_id="123-456-7890",
+            campaign_id="1001",
+            list_name="My List",
+            keywords=["discount"],
+            match_type="phrase",
+        )
+        assert result["changes"]["match_type"] == "PHRASE"
+
+    def test_requires_campaign_id(self, config):
+        result = write.propose_negative_keyword_list(
+            config,
+            list_name="My List",
+            keywords=["free"],
+        )
+        assert result["error"] == "Validation failed"
+        assert any("campaign_id" in d for d in result["details"])
+
+    def test_requires_list_name(self, config):
+        result = write.propose_negative_keyword_list(
+            config,
+            campaign_id="1001",
+            keywords=["free"],
+        )
+        assert result["error"] == "Validation failed"
+        assert any("list_name" in d for d in result["details"])
+
+    def test_requires_at_least_one_keyword(self, config):
+        result = write.propose_negative_keyword_list(
+            config,
+            campaign_id="1001",
+            list_name="My List",
+            keywords=[],
+        )
+        assert result["error"] == "Validation failed"
+        assert any("keyword" in d for d in result["details"])
+
+    def test_rejects_invalid_match_type(self, config):
+        result = write.propose_negative_keyword_list(
+            config,
+            campaign_id="1001",
+            list_name="My List",
+            keywords=["free"],
+            match_type="INVALID",
+        )
+        assert result["error"] == "Validation failed"
+        assert any("match_type" in d for d in result["details"])
+
+    def test_plan_is_stored_and_retrievable(self, config):
+        result = write.propose_negative_keyword_list(
+            config,
+            customer_id="123-456-7890",
+            campaign_id="1001",
+            list_name="Budget Wasters",
+            keywords=["free trial"],
+        )
+        plan_id = result["plan_id"]
+        from adloop.safety import preview as preview_store
+        assert plan_id in preview_store._pending_plans
+
+
 def test_extract_error_message_handles_plain_exceptions():
     assert write._extract_error_message(ValueError("something broke")) == "something broke"
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from adloop.ads import forecast
+from adloop.ads.client import _is_rate_limit_error, call_with_retry
 from adloop.config import AdLoopConfig, AdsConfig, SafetyConfig
 
 
@@ -155,3 +156,70 @@ class TestDiscoverKeywords:
             forecast.discover_keywords(config, seed_keywords=["test"], page_size=9999)
 
         assert request_obj.page_size == 1000
+
+    def test_empty_seed_keywords_without_url_returns_error(self, config):
+        result = forecast.discover_keywords(config, seed_keywords=[])
+        assert "error" in result
+
+    def test_default_seed_keywords_is_empty_list_not_none(self, config):
+        """seed_keywords default must be [] so the MCP schema is array, not anyOf[array,null]."""
+        import inspect
+        sig = inspect.signature(forecast.discover_keywords)
+        default = sig.parameters["seed_keywords"].default
+        assert default == []
+        assert default is not None
+
+
+class TestCallWithRetry:
+    def test_returns_result_on_first_success(self):
+        fn = MagicMock(return_value="ok")
+        assert call_with_retry(fn, "arg", key="val") == "ok"
+        fn.assert_called_once_with("arg", key="val")
+
+    def test_non_rate_limit_error_raises_immediately(self):
+        fn = MagicMock(side_effect=ValueError("unexpected"))
+        with pytest.raises(ValueError, match="unexpected"):
+            call_with_retry(fn, max_attempts=4)
+        fn.assert_called_once()
+
+    def test_retries_on_rate_limit_and_eventually_succeeds(self):
+        rate_limit = Exception("RESOURCE_EXHAUSTED: quota exceeded")
+        fn = MagicMock(side_effect=[rate_limit, rate_limit, "success"])
+        with patch("adloop.ads.client.time.sleep") as mock_sleep:
+            result = call_with_retry(fn, max_attempts=4, base_delay=1.0)
+        assert result == "success"
+        assert fn.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_raises_after_max_attempts_exhausted(self):
+        rate_limit = Exception("RESOURCE_EXHAUSTED: quota exceeded")
+        fn = MagicMock(side_effect=rate_limit)
+        with patch("adloop.ads.client.time.sleep"):
+            with pytest.raises(Exception, match="RESOURCE_EXHAUSTED"):
+                call_with_retry(fn, max_attempts=3, base_delay=0.01)
+        assert fn.call_count == 3
+
+    def test_backoff_delay_grows_exponentially(self):
+        rate_limit = Exception("429 Too Many Requests")
+        fn = MagicMock(side_effect=[rate_limit, rate_limit, "ok"])
+        sleep_calls = []
+        with patch("adloop.ads.client.time.sleep", side_effect=lambda d: sleep_calls.append(d)):
+            with patch("adloop.ads.client.random.uniform", return_value=0.0):
+                call_with_retry(fn, max_attempts=4, base_delay=1.0)
+        assert sleep_calls[0] == pytest.approx(1.0)   # 1.0 * 2^0
+        assert sleep_calls[1] == pytest.approx(2.0)   # 1.0 * 2^1
+
+
+class TestIsRateLimitError:
+    @pytest.mark.parametrize("msg", [
+        "RESOURCE_EXHAUSTED: quota exceeded",
+        "status 429 Too Many Requests",
+        "RATE_LIMIT_EXCEEDED",
+        "QUOTA_EXCEEDED for the day",
+    ])
+    def test_detects_rate_limit_messages(self, msg):
+        assert _is_rate_limit_error(Exception(msg))
+
+    def test_ignores_unrelated_errors(self):
+        assert not _is_rate_limit_error(ValueError("some other error"))
+        assert not _is_rate_limit_error(Exception("INTERNAL: server error"))

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,157 @@
+"""Tests for Keyword Planner forecast and discovery functions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adloop.ads import forecast
+from adloop.config import AdLoopConfig, AdsConfig, SafetyConfig
+
+
+@pytest.fixture
+def config() -> AdLoopConfig:
+    return AdLoopConfig(
+        ads=AdsConfig(customer_id="123-456-7890"),
+        safety=SafetyConfig(require_dry_run=True),
+    )
+
+
+def _make_idea(text, avg_monthly, competition_value, competition_index, low_bid, high_bid):
+    """Build a fake keyword idea proto-like object."""
+    metrics = SimpleNamespace(
+        avg_monthly_searches=avg_monthly,
+        competition=competition_value,
+        competition_index=competition_index,
+        low_top_of_page_bid_micros=low_bid,
+        high_top_of_page_bid_micros=high_bid,
+    )
+    return SimpleNamespace(text=text, keyword_idea_metrics=metrics)
+
+
+class TestDiscoverKeywords:
+    def test_requires_seed_keywords_or_url(self, config):
+        result = forecast.discover_keywords(config)
+        assert result["error"] == "Provide at least one of: seed_keywords or url"
+
+    def test_seed_keywords_only_uses_keyword_seed(self, config):
+        fake_idea = _make_idea("trail running shoes", 5000, 2, 60, 800_000, 2_000_000)
+
+        with patch("adloop.ads.client.get_ads_client") as mock_client_fn:
+            client = MagicMock()
+            mock_client_fn.return_value = client
+
+            # configure resource-path helpers
+            gs = MagicMock()
+            gs.language_constant_path.return_value = "languageConstants/1000"
+            gs.geo_target_constant_path.return_value = "geoTargetConstants/2276"
+            client.get_service.side_effect = lambda name: gs if name == "GoogleAdsService" else MagicMock(generate_keyword_ideas=MagicMock(return_value=[fake_idea]))
+
+            request_obj = MagicMock()
+            client.get_type.return_value = request_obj
+
+            result = forecast.discover_keywords(
+                config,
+                seed_keywords=["trail running"],
+                geo_target_id="2276",
+                language_id="1000",
+            )
+
+        assert result["total_ideas"] == 1
+        assert result["keyword_ideas"][0]["keyword"] == "trail running shoes"
+        assert result["keyword_ideas"][0]["competition"] == "MEDIUM"
+        assert result["keyword_ideas"][0]["avg_monthly_searches"] == 5000
+        assert result["keyword_ideas"][0]["low_top_of_page_bid"] == 0.80
+        assert result["keyword_ideas"][0]["high_top_of_page_bid"] == 2.00
+        assert result["seed_keywords"] == ["trail running"]
+        assert result["seed_url"] == ""
+
+    def test_url_only_uses_url_seed(self, config):
+        fake_idea = _make_idea("running gear", 1200, 1, 20, 400_000, 900_000)
+
+        with patch("adloop.ads.client.get_ads_client") as mock_client_fn:
+            client = MagicMock()
+            mock_client_fn.return_value = client
+
+            gs = MagicMock()
+            gs.language_constant_path.return_value = "languageConstants/1000"
+            gs.geo_target_constant_path.return_value = "geoTargetConstants/2840"
+            client.get_service.side_effect = lambda name: gs if name == "GoogleAdsService" else MagicMock(generate_keyword_ideas=MagicMock(return_value=[fake_idea]))
+
+            request_obj = MagicMock()
+            client.get_type.return_value = request_obj
+
+            result = forecast.discover_keywords(
+                config,
+                url="https://example.com/running",
+                geo_target_id="2840",
+                language_id="1000",
+            )
+
+        assert result["total_ideas"] == 1
+        assert result["keyword_ideas"][0]["competition"] == "LOW"
+        assert result["seed_url"] == "https://example.com/running"
+        assert result["seed_keywords"] == []
+
+    def test_ideas_sorted_by_avg_monthly_searches_descending(self, config):
+        ideas = [
+            _make_idea("low volume", 100, 1, 10, None, None),
+            _make_idea("high volume", 50000, 3, 90, 1_000_000, 3_000_000),
+            _make_idea("mid volume", 5000, 2, 50, 500_000, 1_500_000),
+        ]
+
+        with patch("adloop.ads.client.get_ads_client") as mock_client_fn:
+            client = MagicMock()
+            mock_client_fn.return_value = client
+
+            gs = MagicMock()
+            gs.language_constant_path.return_value = "languageConstants/1000"
+            gs.geo_target_constant_path.return_value = "geoTargetConstants/2276"
+            client.get_service.side_effect = lambda name: gs if name == "GoogleAdsService" else MagicMock(generate_keyword_ideas=MagicMock(return_value=ideas))
+            client.get_type.return_value = MagicMock()
+
+            result = forecast.discover_keywords(config, seed_keywords=["running"])
+
+        volumes = [i["avg_monthly_searches"] for i in result["keyword_ideas"]]
+        assert volumes == sorted(volumes, reverse=True)
+
+    def test_insights_surface_competition_breakdown(self, config):
+        ideas = [
+            _make_idea("cheap option", 200, 1, 15, None, None),
+            _make_idea("popular term", 8000, 3, 85, 2_000_000, 5_000_000),
+        ]
+
+        with patch("adloop.ads.client.get_ads_client") as mock_client_fn:
+            client = MagicMock()
+            mock_client_fn.return_value = client
+
+            gs = MagicMock()
+            gs.language_constant_path.return_value = "languageConstants/1000"
+            gs.geo_target_constant_path.return_value = "geoTargetConstants/2276"
+            client.get_service.side_effect = lambda name: gs if name == "GoogleAdsService" else MagicMock(generate_keyword_ideas=MagicMock(return_value=ideas))
+            client.get_type.return_value = MagicMock()
+
+            result = forecast.discover_keywords(config, seed_keywords=["option"])
+
+        assert any("high-competition" in i for i in result["insights"])
+        assert any("low-competition" in i for i in result["insights"])
+
+    def test_page_size_capped_at_1000(self, config):
+        with patch("adloop.ads.client.get_ads_client") as mock_client_fn:
+            client = MagicMock()
+            mock_client_fn.return_value = client
+
+            gs = MagicMock()
+            gs.language_constant_path.return_value = "languageConstants/1000"
+            gs.geo_target_constant_path.return_value = "geoTargetConstants/2276"
+            kp = MagicMock(generate_keyword_ideas=MagicMock(return_value=[]))
+            client.get_service.side_effect = lambda name: gs if name == "GoogleAdsService" else kp
+
+            request_obj = MagicMock()
+            client.get_type.return_value = request_obj
+
+            forecast.discover_keywords(config, seed_keywords=["test"], page_size=9999)
+
+        assert request_obj.page_size == 1000


### PR DESCRIPTION
Introduces a new write tool that creates a reusable shared negative keyword list (Google Ads SharedSet) and attaches it to a campaign, as an alternative to add_negative_keywords which adds keywords directly to a single campaign.

- ads/write.py: propose_negative_keyword_list() draft function and _apply_create_negative_keyword_list() which calls SharedSetService, SharedCriterionService, and CampaignSharedSetService in sequence
- server.py: MCP tool registration with _WRITE + _safe annotations
- tests/test_ads_write.py: 7 tests covering validation, preview shape, plan storage, and match type normalisation
- .claude/rules/adloop.md: updated tool table and orchestration pattern to guide when to prefer a list vs direct campaign negatives