### PR TITLE
Manage shared negative keyword list contents: append + remove

### DIFF
--- a/.claude/rules/adloop.md
+++ b/.claude/rules/adloop.md
@@ -100,9 +100,10 @@ These tools call both APIs internally and return unified results with computed `
 | `draft_keywords` | Propose keyword additions (does NOT add) | Each keyword needs `text` and `match_type` (EXACT/PHRASE/BROAD) |
 | `add_negative_keywords` | Propose negative keywords directly on a campaign (does NOT add) | `campaign_id`, keyword list, `match_type` |
 | `propose_negative_keyword_list` | Draft a shared negative keyword list and attach it to a campaign (does NOT create) | `campaign_id`, `list_name`, keyword list, `match_type` |
+| `add_to_negative_keyword_list` | Append keywords to an EXISTING shared negative keyword list (does NOT add) | `shared_set_id` (from `get_negative_keyword_lists`), keyword list, `match_type` |
 | `pause_entity` | Propose pausing campaign/ad group/ad/keyword | `entity_type`, `entity_id` |
 | `enable_entity` | Propose enabling paused entity | `entity_type`, `entity_id` |
-| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "campaign_asset", "asset", "customer_asset"), `entity_id` |
+| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "shared_criterion", "campaign_asset", "asset", "customer_asset"), `entity_id` |
 | `confirm_and_apply` | Execute a previously previewed change | `plan_id` from a draft tool, `dry_run` (default true) |
 
 **Write tool workflow:**
@@ -120,7 +121,7 @@ These tools call both APIs internally and return unified results with computed `
 - Ad-group pause/enable is already handled by `pause_entity` / `enable_entity` with `entity_type="ad_group"`; do not invent a separate pause tool.
 - `update_campaign` replaces geo/language targets entirely (not append). Pass the full desired list.
 - `remove_entity` is IRREVERSIBLE — always prefer `pause_entity` unless the user explicitly wants permanent removal. Removal triggers double confirmation in the safety layer.
-- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "campaign_asset", "asset", "customer_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "campaign_asset" to remove sitelinks and other asset links from a campaign. Use "asset" to remove a standalone asset. Use "customer_asset" to remove a customer-level asset link.
+- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "shared_criterion", "campaign_asset", "asset", "customer_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "shared_criterion" to remove a keyword from a shared negative keyword list — the `entity_id` format is "sharedSetId~criterionId" (use the `resource_id` field from `get_negative_keyword_list_keywords`). Use "campaign_asset" to remove sitelinks and other asset links from a campaign. Use "asset" to remove a standalone asset. Use "customer_asset" to remove a customer-level asset link.
 - `require_dry_run: true` in config overrides `dry_run=false` — the user must change the config to allow real mutations.
 - All operations (including dry runs) are logged to `~/.adloop/audit.log`.
 
@@ -287,9 +288,12 @@ Most websites (especially in the EU) use a GDPR cookie consent banner. This has 
 4. Call `get_campaign_performance` to get the right `campaign.id`
 5. Choose the right write tool:
    - **Direct campaign negatives** (`add_negative_keywords`): faster, campaign-specific, no reuse across campaigns
-   - **Shared negative keyword list** (`propose_negative_keyword_list`): creates a named, reusable list that can be attached to multiple campaigns — prefer this when the user wants to reuse the list or when they explicitly mention "list"
-6. **Before calling `propose_negative_keyword_list`**, always call `get_negative_keyword_lists` first to check whether a suitable list already exists. If a matching list is found, inspect its keywords via `get_negative_keyword_list_keywords` and check which campaigns it is already on via `get_negative_keyword_list_campaigns` — it may only need attaching to a new campaign rather than being recreated. Creating duplicate lists wastes account resources and makes management harder.
-7. Present preview and wait for confirmation
+   - **Append to an existing shared list** (`add_to_negative_keyword_list`): pass `shared_set_id` from `get_negative_keyword_lists`. Use this whenever a suitable list already exists — never recreate a list just to add a few more terms.
+   - **Create a new shared list** (`propose_negative_keyword_list`): creates a named, reusable list and attaches it to a campaign. Only use this when no suitable list exists yet.
+6. **Before calling `propose_negative_keyword_list`**, always call `get_negative_keyword_lists` first to check whether a suitable list already exists. If a matching list is found, inspect its keywords via `get_negative_keyword_list_keywords` and check which campaigns it is already on via `get_negative_keyword_list_campaigns`. If the list exists and just needs more keywords, call `add_to_negative_keyword_list` instead of creating a duplicate. Creating duplicate lists wastes account resources and makes management harder.
+7. **Before calling `add_to_negative_keyword_list`**, call `get_negative_keyword_list_keywords` to see what's already in the list — avoid re-adding existing terms. Duplicate keyword additions will fail at apply time with a Google Ads error.
+8. **To remove a keyword from a shared list**, use `remove_entity` with `entity_type="shared_criterion"` and pass the `resource_id` returned by `get_negative_keyword_list_keywords` as `entity_id`. This is irreversible — always confirm with the user first.
+9. Present preview and wait for confirmation
 
 ### When user wants to discover new keywords
 

--- a/.cursor/rules/adloop.mdc
+++ b/.cursor/rules/adloop.mdc
@@ -102,9 +102,10 @@ These tools call both APIs internally and return unified results with computed `
 | `draft_keywords` | Propose keyword additions (does NOT add) | Each keyword needs `text` and `match_type` (EXACT/PHRASE/BROAD) |
 | `add_negative_keywords` | Propose negative keywords directly on a campaign (does NOT add) | `campaign_id`, keyword list, `match_type` |
 | `propose_negative_keyword_list` | Draft a shared negative keyword list and attach it to a campaign (does NOT create) | `campaign_id`, `list_name`, keyword list, `match_type` |
+| `add_to_negative_keyword_list` | Append keywords to an EXISTING shared negative keyword list (does NOT add) | `shared_set_id` (from `get_negative_keyword_lists`), keyword list, `match_type` |
 | `pause_entity` | Propose pausing campaign/ad group/ad/keyword | `entity_type`, `entity_id` |
 | `enable_entity` | Propose enabling paused entity | `entity_type`, `entity_id` |
-| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "campaign_asset", "asset", "customer_asset"), `entity_id` |
+| `remove_entity` | Propose REMOVING an entity (irreversible) | `entity_type` (incl. "negative_keyword", "shared_criterion", "campaign_asset", "asset", "customer_asset"), `entity_id` |
 | `confirm_and_apply` | Execute a previously previewed change | `plan_id` from a draft tool, `dry_run` (default true) |
 
 **Write tool workflow:**
@@ -122,7 +123,7 @@ These tools call both APIs internally and return unified results with computed `
 - Ad-group pause/enable is already handled by `pause_entity` / `enable_entity` with `entity_type="ad_group"`; do not invent a separate pause tool.
 - `update_campaign` replaces geo/language targets entirely (not append). Pass the full desired list.
 - `remove_entity` is IRREVERSIBLE — always prefer `pause_entity` unless the user explicitly wants permanent removal. Removal triggers double confirmation in the safety layer.
-- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "campaign_asset", "asset", "customer_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "campaign_asset" to remove sitelinks and other asset links from a campaign. Use "asset" to remove a standalone asset. Use "customer_asset" to remove a customer-level asset link.
+- `remove_entity` supports `entity_type` values: "campaign", "ad_group", "ad", "keyword", "negative_keyword", "shared_criterion", "campaign_asset", "asset", "customer_asset". Use "negative_keyword" to remove campaign-level negative keywords. Use "shared_criterion" to remove a keyword from a shared negative keyword list — the `entity_id` format is "sharedSetId~criterionId" (use the `resource_id` field from `get_negative_keyword_list_keywords`). Use "campaign_asset" to remove sitelinks and other asset links from a campaign. Use "asset" to remove a standalone asset. Use "customer_asset" to remove a customer-level asset link.
 - `require_dry_run: true` in config overrides `dry_run=false` — the user must change the config to allow real mutations.
 - All operations (including dry runs) are logged to `~/.adloop/audit.log`.
 
@@ -289,9 +290,12 @@ Most websites (especially in the EU) use a GDPR cookie consent banner. This has 
 4. Call `get_campaign_performance` to get the right `campaign.id`
 5. Choose the right write tool:
    - **Direct campaign negatives** (`add_negative_keywords`): faster, campaign-specific, no reuse across campaigns
-   - **Shared negative keyword list** (`propose_negative_keyword_list`): creates a named, reusable list that can be attached to multiple campaigns — prefer this when the user wants to reuse the list or when they explicitly mention "list"
-6. **Before calling `propose_negative_keyword_list`**, always call `get_negative_keyword_lists` first to check whether a suitable list already exists. If a matching list is found, inspect its keywords via `get_negative_keyword_list_keywords` and check which campaigns it is already on via `get_negative_keyword_list_campaigns` — it may only need attaching to a new campaign rather than being recreated. Creating duplicate lists wastes account resources and makes management harder.
-7. Present preview and wait for confirmation
+   - **Append to an existing shared list** (`add_to_negative_keyword_list`): pass `shared_set_id` from `get_negative_keyword_lists`. Use this whenever a suitable list already exists — never recreate a list just to add a few more terms.
+   - **Create a new shared list** (`propose_negative_keyword_list`): creates a named, reusable list and attaches it to a campaign. Only use this when no suitable list exists yet.
+6. **Before calling `propose_negative_keyword_list`**, always call `get_negative_keyword_lists` first to check whether a suitable list already exists. If a matching list is found, inspect its keywords via `get_negative_keyword_list_keywords` and check which campaigns it is already on via `get_negative_keyword_list_campaigns`. If the list exists and just needs more keywords, call `add_to_negative_keyword_list` instead of creating a duplicate. Creating duplicate lists wastes account resources and makes management harder.
+7. **Before calling `add_to_negative_keyword_list`**, call `get_negative_keyword_list_keywords` to see what's already in the list — avoid re-adding existing terms. Duplicate keyword additions will fail at apply time with a Google Ads error.
+8. **To remove a keyword from a shared list**, use `remove_entity` with `entity_type="shared_criterion"` and pass the `resource_id` returned by `get_negative_keyword_list_keywords` as `entity_id`. This is irreversible — always confirm with the user first.
+9. Present preview and wait for confirmation
 
 ### When user wants to discover new keywords
 

--- a/src/adloop/ads/read.py
+++ b/src/adloop/ads/read.py
@@ -267,7 +267,8 @@ def get_negative_keyword_list_keywords(
         return {"error": "shared_set_id must be a numeric ID"}
 
     query = f"""
-        SELECT shared_criterion.keyword.text,
+        SELECT shared_criterion.criterion_id,
+               shared_criterion.keyword.text,
                shared_criterion.keyword.match_type,
                shared_criterion.type,
                shared_set.id, shared_set.name
@@ -277,6 +278,11 @@ def get_negative_keyword_list_keywords(
     """
 
     rows = execute_query(config, customer_id, query)
+    for row in rows:
+        ssid = row.get("shared_set.id")
+        crit_id = row.get("shared_criterion.criterion_id")
+        if ssid and crit_id:
+            row["resource_id"] = f"{ssid}~{crit_id}"
     return {
         "keywords": rows,
         "total_keywords": len(rows),

--- a/src/adloop/ads/write.py
+++ b/src/adloop/ads/write.py
@@ -396,6 +396,77 @@ def propose_negative_keyword_list(
     return plan.to_preview()
 
 
+def add_to_negative_keyword_list(
+    config: AdLoopConfig,
+    *,
+    customer_id: str = "",
+    shared_set_id: str = "",
+    keywords: list[str] | None = None,
+    match_type: str = "EXACT",
+) -> dict:
+    """Draft adding keywords to an existing shared negative keyword list — returns PREVIEW.
+
+    Unlike ``propose_negative_keyword_list`` (which creates a NEW list), this
+    appends keywords to an existing SharedSet identified by ``shared_set_id``.
+    Use ``get_negative_keyword_lists`` to find the list's ID. Call
+    ``confirm_and_apply`` with the returned plan_id to execute.
+    """
+    from adloop.safety.guards import SafetyViolation, check_blocked_operation
+    from adloop.safety.preview import ChangePlan, store_plan
+
+    try:
+        check_blocked_operation("add_to_negative_keyword_list", config.safety)
+    except SafetyViolation as e:
+        return {"error": str(e)}
+
+    keywords = keywords or []
+    match_type = match_type.upper()
+
+    errors = []
+    if not shared_set_id:
+        errors.append("shared_set_id is required")
+    elif not str(shared_set_id).isdigit():
+        errors.append("shared_set_id must be a numeric ID (from get_negative_keyword_lists)")
+    if not keywords:
+        errors.append("At least one keyword is required")
+    if match_type not in _VALID_MATCH_TYPES:
+        errors.append(f"Invalid match_type '{match_type}' — use EXACT, PHRASE, or BROAD")
+    if errors:
+        return {"error": "Validation failed", "details": errors}
+
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for kw in keywords:
+        text = kw.strip()
+        if not text:
+            continue
+        key = text.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(text)
+
+    if not deduped:
+        return {
+            "error": "Validation failed",
+            "details": ["At least one non-empty keyword is required"],
+        }
+
+    plan = ChangePlan(
+        operation="add_to_negative_keyword_list",
+        entity_type="negative_keyword_list",
+        entity_id=str(shared_set_id),
+        customer_id=customer_id,
+        changes={
+            "shared_set_id": str(shared_set_id),
+            "keywords": deduped,
+            "match_type": match_type,
+        },
+    )
+    store_plan(plan)
+    return plan.to_preview()
+
+
 def update_ad_group(
     config: AdLoopConfig,
     *,
@@ -1167,6 +1238,7 @@ _VALID_MATCH_TYPES = {"EXACT", "PHRASE", "BROAD"}
 _VALID_ENTITY_TYPES = {"campaign", "ad_group", "ad", "keyword"}
 _REMOVABLE_ENTITY_TYPES = _VALID_ENTITY_TYPES | {
     "negative_keyword", "campaign_asset", "asset", "customer_asset",
+    "shared_criterion",
 }
 
 _SMART_BIDDING_STRATEGIES = {
@@ -1726,6 +1798,7 @@ def _execute_plan(config: AdLoopConfig, plan: object) -> dict:
         "add_keywords": _apply_add_keywords,
         "add_negative_keywords": _apply_add_negative_keywords,
         "create_negative_keyword_list": _apply_create_negative_keyword_list,
+        "add_to_negative_keyword_list": _apply_add_to_negative_keyword_list,
         "pause_entity": _apply_status_change,
         "enable_entity": _apply_status_change,
         "remove_entity": _apply_remove,
@@ -2282,6 +2355,19 @@ def _apply_remove(
             customer_id=cid, operations=[operation]
         )
 
+    elif entity_type == "shared_criterion":
+        if "~" not in entity_id:
+            raise ValueError(
+                f"shared_criterion entity_id must be "
+                f"'sharedSetId~criterionId', got '{entity_id}'"
+            )
+        service = client.get_service("SharedCriterionService")
+        operation = client.get_type("SharedCriterionOperation")
+        operation.remove = f"customers/{cid}/sharedCriteria/{entity_id}"
+        response = service.mutate_shared_criteria(
+            customer_id=cid, operations=[operation]
+        )
+
     elif entity_type == "campaign_asset":
         parts = entity_id.split("~")
         if len(parts) != 3:
@@ -2598,4 +2684,35 @@ def _apply_create_negative_keyword_list(
         "shared_set_resource": shared_set_resource,
         "campaign_shared_set_resource": css_response.results[0].resource_name,
         "keyword_count": len(changes["keywords"]),
+    }
+
+
+def _apply_add_to_negative_keyword_list(
+    client: object, cid: str, changes: dict
+) -> dict:
+    """Append keywords to an existing shared negative keyword list."""
+    shared_set_service = client.get_service("SharedSetService")
+    shared_set_resource = shared_set_service.shared_set_path(
+        cid, changes["shared_set_id"]
+    )
+
+    sc_service = client.get_service("SharedCriterionService")
+    operations = []
+    for kw_text in changes["keywords"]:
+        op = client.get_type("SharedCriterionOperation")
+        criterion = op.create
+        criterion.shared_set = shared_set_resource
+        criterion.keyword.text = kw_text
+        criterion.keyword.match_type = getattr(
+            client.enums.KeywordMatchTypeEnum, changes["match_type"]
+        )
+        operations.append(op)
+
+    response = sc_service.mutate_shared_criteria(
+        customer_id=cid, operations=operations
+    )
+    return {
+        "shared_set_resource": shared_set_resource,
+        "resource_names": [r.resource_name for r in response.results],
+        "keyword_count": len(response.results),
     }

--- a/src/adloop/server.py
+++ b/src/adloop/server.py
@@ -981,6 +981,39 @@ def propose_negative_keyword_list(
 
 @mcp.tool(annotations=_WRITE)
 @_safe
+def add_to_negative_keyword_list(
+    shared_set_id: str,
+    keywords: list[str],
+    customer_id: str = "",
+    match_type: str = "EXACT",
+) -> dict:
+    """Append keywords to an EXISTING shared negative keyword list — returns a PREVIEW.
+
+    Use this when a suitable list already exists and only needs more keywords
+    (instead of propose_negative_keyword_list, which creates a new list).
+    Always call get_negative_keyword_lists first to find the right shared_set_id
+    and get_negative_keyword_list_keywords to avoid duplicating existing terms.
+
+    shared_set_id: numeric ID from get_negative_keyword_lists (shared_set.id).
+    keywords: list of keyword strings to append (duplicates in the input list
+        are collapsed).
+    match_type: "EXACT", "PHRASE", or "BROAD"
+
+    Call confirm_and_apply with the returned plan_id to execute.
+    """
+    from adloop.ads.write import add_to_negative_keyword_list as _impl
+
+    return _impl(
+        _config,
+        customer_id=customer_id or _config.ads.customer_id,
+        shared_set_id=shared_set_id,
+        keywords=keywords,
+        match_type=match_type,
+    )
+
+
+@mcp.tool(annotations=_WRITE)
+@_safe
 def update_ad_group(
     ad_group_id: str,
     customer_id: str = "",
@@ -1119,11 +1152,13 @@ def remove_entity(
     """Draft REMOVING an entity — returns a PREVIEW. This is IRREVERSIBLE.
 
     entity_type: "campaign", "ad_group", "ad", "keyword", "negative_keyword",
-                 "campaign_asset", "asset", or "customer_asset"
+                 "shared_criterion", "campaign_asset", "asset", or "customer_asset"
     entity_id: The resource ID.
                For keywords: "adGroupId~criterionId"
                For negative_keywords: "campaignId~criterionId"
                    (use the resource_id field from get_negative_keywords)
+               For shared_criterion: "sharedSetId~criterionId"
+                   (use the resource_id field from get_negative_keyword_list_keywords)
                For campaign_asset: "campaignId~assetId~fieldType"
                For asset: simple asset ID
                For customer_asset: "assetId~fieldType"

--- a/tests/evals/write.json
+++ b/tests/evals/write.json
@@ -83,6 +83,30 @@
       ]
     },
     {
+      "id": 10,
+      "prompt": "Remove 'test keyword' from my 'Brand negatives' shared negative keyword list.",
+      "expected_output": "Should call get_negative_keyword_lists to find the shared_set_id, then get_negative_keyword_list_keywords to find the target criterion's resource_id, then remove_entity with entity_type='shared_criterion' and the resource_id as entity_id. Should warn that removal is irreversible and wait for confirmation.",
+      "expectations": [
+        "Calls get_negative_keyword_lists to find the shared_set_id of 'Brand negatives'",
+        "Calls get_negative_keyword_list_keywords to find the resource_id for 'test keyword'",
+        "Calls remove_entity with entity_type='shared_criterion' and the resource_id as entity_id",
+        "Warns that the removal is irreversible before proceeding",
+        "Presents the preview and waits for user confirmation"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "I already have a shared negative keyword list called 'Brand Exclusions' in my account. Add 'free trial' and 'crack' to it.",
+      "expected_output": "Should call get_negative_keyword_lists to find the list's shared_set_id, optionally call get_negative_keyword_list_keywords to avoid duplicates, then call add_to_negative_keyword_list — NOT propose_negative_keyword_list (which would create a duplicate list).",
+      "expectations": [
+        "Calls get_negative_keyword_lists to look up the shared_set_id of the existing list",
+        "Does NOT call propose_negative_keyword_list (which would create a duplicate)",
+        "Calls add_to_negative_keyword_list with the correct shared_set_id, keywords, and match_type",
+        "Considers calling get_negative_keyword_list_keywords first to avoid re-adding existing terms",
+        "Presents the preview and waits for user confirmation before applying"
+      ]
+    },
+    {
       "id": 8,
       "prompt": "Apply the change from plan id abc123, make it live not dry run",
       "expected_output": "Should confirm the user has reviewed the preview, call confirm_and_apply with dry_run=false, remind about require_dry_run config override.",

--- a/tests/test_ads_write.py
+++ b/tests/test_ads_write.py
@@ -589,6 +589,51 @@ def test_apply_remove_customer_asset_preserves_tildes_in_resource_name():
     assert "," not in resource_name
 
 
+def test_apply_remove_shared_criterion_uses_shared_criterion_service():
+    """Removing a shared-list keyword must go through SharedCriterionService."""
+    captured: dict = {}
+
+    def _mutate(customer_id, operations):
+        captured["customer_id"] = customer_id
+        captured["operations"] = list(operations)
+        return SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    resource_name=f"customers/{customer_id}/sharedCriteria/555~9001"
+                )
+            ]
+        )
+
+    shared_criterion_service = SimpleNamespace(mutate_shared_criteria=_mutate)
+    client = _FakeClient({"SharedCriterionService": shared_criterion_service})
+
+    result = write._apply_remove(client, "1234567890", "shared_criterion", "555~9001")
+
+    assert captured["customer_id"] == "1234567890"
+    assert captured["operations"][0].remove == "customers/1234567890/sharedCriteria/555~9001"
+    assert result["resource_name"] == "customers/1234567890/sharedCriteria/555~9001"
+
+
+def test_apply_remove_shared_criterion_rejects_bare_id():
+    """shared_criterion entity_id without a ~ separator is a caller error."""
+    client = _FakeClient({})
+    with pytest.raises(ValueError, match="sharedSetId~criterionId"):
+        write._apply_remove(client, "1234567890", "shared_criterion", "9001")
+
+
+def test_remove_entity_accepts_shared_criterion_type(config):
+    """remove_entity should accept shared_criterion as a valid entity_type."""
+    result = write.remove_entity(
+        config,
+        customer_id="123-456-7890",
+        entity_type="shared_criterion",
+        entity_id="555~9001",
+    )
+    assert result["entity_type"] == "shared_criterion"
+    assert result["entity_id"] == "555~9001"
+    assert result["status"] == "PENDING_CONFIRMATION"
+
+
 def test_remove_entity_normalizes_commas_to_tildes(config):
     """remove_entity should accept commas and normalize to tildes in the stored plan."""
     result = write.remove_entity(
@@ -683,6 +728,163 @@ class TestProposeNegativeKeywordList:
         assert plan_id in preview_store._pending_plans
 
 
+class TestAddToNegativeKeywordList:
+    def test_returns_preview_with_correct_operation(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            customer_id="123-456-7890",
+            shared_set_id="555",
+            keywords=["free trial", "crack"],
+            match_type="EXACT",
+        )
+        assert result["operation"] == "add_to_negative_keyword_list"
+        assert result["entity_type"] == "negative_keyword_list"
+        assert result["entity_id"] == "555"
+        assert result["changes"]["shared_set_id"] == "555"
+        assert result["changes"]["keywords"] == ["free trial", "crack"]
+        assert result["changes"]["match_type"] == "EXACT"
+        assert result["status"] == "PENDING_CONFIRMATION"
+        assert "plan_id" in result
+
+    def test_normalises_match_type_to_uppercase(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="555",
+            keywords=["discount"],
+            match_type="phrase",
+        )
+        assert result["changes"]["match_type"] == "PHRASE"
+
+    def test_requires_shared_set_id(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            keywords=["free"],
+        )
+        assert result["error"] == "Validation failed"
+        assert any("shared_set_id" in d for d in result["details"])
+
+    def test_rejects_non_numeric_shared_set_id(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="abc; DROP TABLE",
+            keywords=["free"],
+        )
+        assert result["error"] == "Validation failed"
+        assert any("numeric" in d for d in result["details"])
+
+    def test_requires_at_least_one_keyword(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="555",
+            keywords=[],
+        )
+        assert result["error"] == "Validation failed"
+        assert any("keyword" in d.lower() for d in result["details"])
+
+    def test_rejects_invalid_match_type(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="555",
+            keywords=["free"],
+            match_type="INVALID",
+        )
+        assert result["error"] == "Validation failed"
+        assert any("match_type" in d for d in result["details"])
+
+    def test_collapses_duplicate_keywords_case_insensitively(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="555",
+            keywords=["Free Trial", "free trial", "FREE TRIAL", "crack"],
+        )
+        assert result["changes"]["keywords"] == ["Free Trial", "crack"]
+
+    def test_ignores_whitespace_only_keywords(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="555",
+            keywords=["   ", "real term", ""],
+        )
+        assert result["changes"]["keywords"] == ["real term"]
+
+    def test_all_empty_keywords_rejected(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="555",
+            keywords=["", "   "],
+        )
+        assert result["error"] == "Validation failed"
+
+    def test_plan_is_stored_and_retrievable(self, config):
+        result = write.add_to_negative_keyword_list(
+            config,
+            shared_set_id="555",
+            keywords=["free trial"],
+        )
+        assert result["plan_id"] in preview_store._pending_plans
+
+
+class TestApplyAddToNegativeKeywordList:
+    """Tests for _apply_add_to_negative_keyword_list — the single-step append mutate."""
+
+    def _make_client(self):
+        captured: dict = {}
+
+        def _mutate(customer_id, operations):
+            captured["customer_id"] = customer_id
+            captured["operations"] = list(operations)
+            return SimpleNamespace(
+                results=[
+                    SimpleNamespace(resource_name=f"customers/{customer_id}/sharedCriteria/555~{i}")
+                    for i, _ in enumerate(operations)
+                ]
+            )
+
+        shared_set_service = SimpleNamespace(
+            shared_set_path=lambda cid, ssid: f"customers/{cid}/sharedSets/{ssid}",
+        )
+        shared_criterion_service = SimpleNamespace(
+            mutate_shared_criteria=_mutate,
+        )
+        services = {
+            "SharedSetService": shared_set_service,
+            "SharedCriterionService": shared_criterion_service,
+        }
+        return _FakeClient(services), captured
+
+    def test_returns_resource_names_and_shared_set(self):
+        client, captured = self._make_client()
+        result = write._apply_add_to_negative_keyword_list(
+            client,
+            "1234567890",
+            {
+                "shared_set_id": "555",
+                "keywords": ["free", "crack"],
+                "match_type": "EXACT",
+            },
+        )
+        assert result["shared_set_resource"] == "customers/1234567890/sharedSets/555"
+        assert result["keyword_count"] == 2
+        assert len(result["resource_names"]) == 2
+        assert captured["customer_id"] == "1234567890"
+        assert len(captured["operations"]) == 2
+
+    def test_each_operation_references_shared_set(self):
+        client, captured = self._make_client()
+        write._apply_add_to_negative_keyword_list(
+            client,
+            "1234567890",
+            {
+                "shared_set_id": "555",
+                "keywords": ["one"],
+                "match_type": "PHRASE",
+            },
+        )
+        op = captured["operations"][0]
+        assert op.create.shared_set == "customers/1234567890/sharedSets/555"
+        assert op.create.keyword.text == "one"
+
+
 class TestGetNegativeKeywordLists:
     def test_returns_list_of_shared_sets(self, config, monkeypatch):
         fake_rows = [
@@ -731,6 +933,25 @@ class TestGetNegativeKeywordListKeywords:
         assert result["total_keywords"] == 1
         assert result["shared_set_id"] == "111"
         assert result["keywords"][0]["shared_criterion.keyword.text"] == "free"
+
+    def test_emits_resource_id_for_remove_entity(self, config, monkeypatch):
+        """Each keyword should carry a resource_id for feeding into remove_entity."""
+        fake_rows = [
+            {
+                "shared_criterion.criterion_id": "9001",
+                "shared_criterion.keyword.text": "free",
+                "shared_criterion.keyword.match_type": "EXACT",
+                "shared_set.id": "111",
+                "shared_set.name": "Brand Exclusions",
+            }
+        ]
+        monkeypatch.setattr(
+            "adloop.ads.gaql.execute_query", lambda *_a, **_kw: fake_rows
+        )
+        result = read.get_negative_keyword_list_keywords(
+            config, customer_id="123-456-7890", shared_set_id="111"
+        )
+        assert result["keywords"][0]["resource_id"] == "111~9001"
 
 
 class TestGetNegativeKeywordListCampaigns:


### PR DESCRIPTION
## Summary

Shared negative keyword lists (SharedSets) were a one-way street before this PR: you could create a new list via `propose_negative_keyword_list`, but once it existed there was no way to modify its contents through MCP. The orchestration rules already told the AI to check for existing lists before creating new ones — but without any modification tools, that check only ever led to a dead end (the AI would find a matching list, then create a duplicate anyway because that was the only writable tool).

This PR closes the loop with two complementary tools and one read-tool enhancement. Together they complete the shared-list lifecycle (create → append → remove), each through the same preview / dry-run / confirm safety layer as every other write tool.

## What's new

### 1. `add_to_negative_keyword_list(shared_set_id, keywords, match_type)`
Appends keywords to an existing SharedSet instead of forcing a new list. Implementation notes:
- Validates `shared_set_id` is numeric (prevents injection in any downstream GAQL lookup and catches obvious caller errors early).
- Collapses case-insensitive duplicates and whitespace-only entries in the input list so repeated calls / sloppy inputs don't blow up at apply time.
- Routes through the standard `ChangePlan` → `store_plan` → `confirm_and_apply` path — identical semantics to `propose_negative_keyword_list`, just different mutate target.
- Executor (`_apply_add_to_negative_keyword_list`) calls `SharedCriterionService.mutate_shared_criteria` with one op per keyword, constructing the `shared_set` resource via `shared_set_path(cid, shared_set_id)`.

### 2. `remove_entity` now accepts `entity_type=\"shared_criterion\"`
No new top-level tool — just a new value in the existing `_REMOVABLE_ENTITY_TYPES` set and a new `elif` branch in `_apply_remove`. Rationale: removal is semantically identical to the existing `negative_keyword` removal (both are criteria), just against a different service. Adding it as a top-level tool would have been asymmetric with how campaign-level negatives are removed today.
- Resource name format: `customers/{cid}/sharedCriteria/{sharedSetId~criterionId}`.
- `entity_id` must be the composite `sharedSetId~criterionId`; a bare id raises a `ValueError` at plan time rather than producing an opaque API error at apply time.
- Still irreversible, still covered by the destructive-operation safety annotations.

### 3. `get_negative_keyword_list_keywords` now returns `resource_id`
The read tool now adds `shared_criterion.criterion_id` to the SELECT and emits a pre-formatted `resource_id` field (`\"sharedSetId~criterionId\"`) on each row. Callers (human or AI) feed it straight into `remove_entity` without having to assemble the composite id themselves. Mirrors the existing `resource_id` pattern on `get_negative_keywords`.

## Why these three together

The three changes are tightly coupled by the user workflow: \"find the list I want → see what's in it → add or remove.\" Shipping `add_to_negative_keyword_list` without `shared_criterion` removal would have left a one-way door just on the new side (easy to add a keyword, can't take it back out without the Google Ads UI). Shipping the removal without the `resource_id` helper would have forced every caller to hand-assemble composite IDs. All three in one PR keeps the lifecycle coherent.

## Test plan

- [x] 16 new unit tests added (135 passing total, up from 131)
  - `TestAddToNegativeKeywordList` (10): preview shape, match_type normalization, numeric `shared_set_id` enforcement, empty/whitespace keyword rejection, case-insensitive dedup, plan storage
  - `TestApplyAddToNegativeKeywordList` (2): `SharedCriterionService` wiring, per-op `shared_set` path and keyword text assertions
  - Remove path (3): `remove_entity` accepts `shared_criterion`, `_apply_remove` routes to `SharedCriterionService`, malformed id rejected
  - Read tool (1): `resource_id` field emitted on each keyword row
- [x] 2 new behavioral evals in `tests/evals/write.json`
  - Eval #9: AI should prefer `add_to_negative_keyword_list` when the target list already exists instead of calling `propose_negative_keyword_list` (which would create a duplicate).
  - Eval #10: AI should use `entity_type=\"shared_criterion\"` with an irreversibility warning when removing a keyword from a shared list.
- [x] Orchestration rules updated in `.cursor/rules/adloop.mdc` and synced to `.claude/rules/adloop.md` via `scripts/sync-rules.py`. The negative-keyword pattern now documents the three-way branch (direct campaign negative / append to existing list / create new list) and the removal path.
- [x] **Verified end-to-end against the live Google Ads API** on customer `929-592-0823`, shared set `\"Brand negatives\"` (id `12048182782`):
  - `add_to_negative_keyword_list` appended `\"test keyword\"` (PHRASE) → `confirm_and_apply(dry_run=false)` → list grew 3 → 4 (verified via `get_negative_keyword_list_keywords`)
  - `remove_entity(shared_criterion, 12048182782~305262791)` → `confirm_and_apply(dry_run=false)` → list back to 3 (verified)
  - `resource_id` field visible on all rows in the post-remove read

## Not covered (intentional)

- `_execute_plan` dispatch dict entry — one-line lookup, no test exists for any other op either, no regression surface.
- MCP tool registration in `server.py` — project has no tests for this layer.

## Files changed

- `src/adloop/ads/write.py` — new draft fn + executor + `_apply_remove` branch + allow-list extension
- `src/adloop/ads/read.py` — `resource_id` field on `get_negative_keyword_list_keywords`
- `src/adloop/server.py` — new MCP tool registration + `remove_entity` docstring update
- `tests/test_ads_write.py` — 16 new tests
- `tests/evals/write.json` — 2 new behavioral evals
- `.cursor/rules/adloop.mdc` + synced `.claude/rules/adloop.md` — docs