### PR TITLE
Bump workflow actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
 
@@ -23,7 +23,7 @@ jobs:
       - name: Build package
         run: uv build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary

The v0.6.0 release workflow surfaced deprecation warnings for every GitHub Action in both `ci.yml` and `release.yml`. GitHub is forcing Node 24 by default starting **June 2, 2026**, and removing Node 20 from runners on **September 16, 2026**. Bumps all actions to their stable Node-24-by-default majors.

## Changes

- `actions/checkout`: v4 → **v5** (Node 24, released Aug 2025)
- `astral-sh/setup-uv`: v5 → **v7** (Node 24, released Oct 2025)
- `actions/upload-artifact`: v4 → **v6** (Node 24 by default, released Dec 2025) — `release.yml` only
- `actions/download-artifact`: v4 → **v7** (Node 24 by default, released Dec 2025) — `release.yml` only

`upload-artifact@v6` and `download-artifact@v7` share the same `@actions/artifact@v4` internals and are the matched Node-24 pair (both released 2025-12-12), so the upload → download handoff across the `build` → `publish` jobs in `release.yml` stays compatible.

No changes to job structure, permissions, matrix, or the PyPI trusted-publisher flow. CI on this PR is the actual test — if it goes green across the 3.11/3.12/3.13 matrix, the workflows are functionally equivalent.

## Test plan

- [ ] CI workflow runs green across Python 3.11, 3.12, 3.13 on this PR
- [ ] No Node 20 deprecation warnings in the Actions annotations
- [ ] Next `v*` tag cleanly builds, publishes to PyPI, and creates a GitHub release (will verify on the next real release)

## Not in scope

Separate annotation from the v0.6.0 run: `No file matched to [**/uv.lock,**/requirements*.txt]. The cache will never get invalidated.` That's because `uv.lock` is gitignored, so the `setup-uv` cache key never has anything to hash. Fixing that is a separate decision (commit the lock file, or disable the cache) — not folded in here.