### PR TITLE
feat(rsa): support pinned_field on headlines/descriptions

### DIFF
--- a/src/adloop/ads/write.py
+++ b/src/adloop/ads/write.py
@@ -37,6 +37,34 @@ _VALID_IMAGE_MIME_TYPES = {
     "image/png": "IMAGE_PNG",
 }
 
+_VALID_HEADLINE_PINS = {"HEADLINE_1", "HEADLINE_2", "HEADLINE_3"}
+_VALID_DESCRIPTION_PINS = {"DESCRIPTION_1", "DESCRIPTION_2"}
+
+
+def _normalize_rsa_assets(items: list) -> list[dict]:
+    """Accept str or {text, pinned_field?} dict entries; return list of dicts.
+
+    Plain strings are treated as unpinned. Dict entries may include an optional
+    ``pinned_field`` key whose value must be a valid pin slot for the asset
+    role (validated by ``_validate_rsa``).
+    """
+    out: list[dict] = []
+    for item in items:
+        if isinstance(item, str):
+            out.append({"text": item, "pinned_field": None})
+        elif isinstance(item, dict):
+            out.append(
+                {
+                    "text": item.get("text", ""),
+                    "pinned_field": item.get("pinned_field"),
+                }
+            )
+        else:
+            raise ValueError(
+                f"RSA asset entry must be str or dict, got {type(item).__name__}"
+            )
+    return out
+
 
 # ---------------------------------------------------------------------------
 # URL validation — verify URLs exist before creating ads/sitelinks
@@ -192,13 +220,27 @@ def draft_responsive_search_ad(
     *,
     customer_id: str = "",
     ad_group_id: str = "",
-    headlines: list[str] | None = None,
-    descriptions: list[str] | None = None,
+    headlines: list[str | dict] | None = None,
+    descriptions: list[str | dict] | None = None,
     final_url: str = "",
     path1: str = "",
     path2: str = "",
 ) -> dict:
-    """Draft a Responsive Search Ad — returns preview, does NOT execute."""
+    """Draft a Responsive Search Ad — returns preview, does NOT execute.
+
+    Each headline/description entry may be either:
+
+    - a plain string (unpinned), or
+    - a dict ``{"text": "...", "pinned_field": "HEADLINE_1"}`` (pinned).
+
+    Valid pin values:
+        headlines:    HEADLINE_1, HEADLINE_2, HEADLINE_3
+        descriptions: DESCRIPTION_1, DESCRIPTION_2
+
+    Google caps: at most 2 headlines per pin slot, at most 1 description per
+    pin slot. Mixed plain-string and dict entries are allowed within a single
+    call (e.g. brand pinned to HEADLINE_1, the rest unpinned).
+    """
     from adloop.safety.guards import SafetyViolation, check_blocked_operation
     from adloop.safety.preview import ChangePlan, store_plan
 
@@ -209,6 +251,12 @@ def draft_responsive_search_ad(
 
     headlines = headlines or []
     descriptions = descriptions or []
+
+    try:
+        headlines = _normalize_rsa_assets(headlines)
+        descriptions = _normalize_rsa_assets(descriptions)
+    except ValueError as e:
+        return {"error": "Validation failed", "details": [str(e)]}
 
     errors = _validate_rsa(ad_group_id, headlines, descriptions, final_url)
     if errors:
@@ -1465,8 +1513,8 @@ def _check_broad_match_safety(
 
 def _validate_rsa(
     ad_group_id: str,
-    headlines: list[str],
-    descriptions: list[str],
+    headlines: list[dict],
+    descriptions: list[dict],
     final_url: str,
 ) -> list[str]:
     errors = []
@@ -1482,12 +1530,47 @@ def _validate_rsa(
         errors.append(f"Need at least 2 descriptions, got {len(descriptions)}")
     if len(descriptions) > 4:
         errors.append(f"Maximum 4 descriptions, got {len(descriptions)}")
+
+    headline_pin_counts: dict[str, int] = {}
     for i, h in enumerate(headlines):
-        if len(h) > 30:
-            errors.append(f"Headline {i + 1} exceeds 30 chars ({len(h)}): '{h}'")
+        text = h["text"]
+        pin = h["pinned_field"]
+        if len(text) > 30:
+            errors.append(
+                f"Headline {i + 1} exceeds 30 chars ({len(text)}): '{text}'"
+            )
+        if pin is not None:
+            if pin not in _VALID_HEADLINE_PINS:
+                errors.append(
+                    f"Headline {i + 1} pinned_field '{pin}' invalid; "
+                    f"must be one of {sorted(_VALID_HEADLINE_PINS)} or null"
+                )
+            else:
+                headline_pin_counts[pin] = headline_pin_counts.get(pin, 0) + 1
+    for pin, count in headline_pin_counts.items():
+        if count > 2:
+            errors.append(f"At most 2 headlines may pin to {pin}; got {count}")
+
+    description_pin_counts: dict[str, int] = {}
     for i, d in enumerate(descriptions):
-        if len(d) > 90:
-            errors.append(f"Description {i + 1} exceeds 90 chars ({len(d)}): '{d}'")
+        text = d["text"]
+        pin = d["pinned_field"]
+        if len(text) > 90:
+            errors.append(
+                f"Description {i + 1} exceeds 90 chars ({len(text)}): '{text}'"
+            )
+        if pin is not None:
+            if pin not in _VALID_DESCRIPTION_PINS:
+                errors.append(
+                    f"Description {i + 1} pinned_field '{pin}' invalid; "
+                    f"must be one of {sorted(_VALID_DESCRIPTION_PINS)} or null"
+                )
+            else:
+                description_pin_counts[pin] = description_pin_counts.get(pin, 0) + 1
+    for pin, count in description_pin_counts.items():
+        if count > 1:
+            errors.append(f"At most 1 description may pin to {pin}; got {count}")
+
     return errors
 
 
@@ -2253,14 +2336,22 @@ def _apply_create_rsa(client: object, cid: str, changes: dict) -> dict:
     ad = ad_group_ad.ad
     ad.final_urls.append(changes["final_url"])
 
-    for text in changes["headlines"]:
+    for entry in changes["headlines"]:
         asset = client.get_type("AdTextAsset")
-        asset.text = text
+        asset.text = entry["text"]
+        if entry.get("pinned_field"):
+            asset.pinned_field = client.enums.ServedAssetFieldTypeEnum[
+                entry["pinned_field"]
+            ]
         ad.responsive_search_ad.headlines.append(asset)
 
-    for text in changes["descriptions"]:
+    for entry in changes["descriptions"]:
         asset = client.get_type("AdTextAsset")
-        asset.text = text
+        asset.text = entry["text"]
+        if entry.get("pinned_field"):
+            asset.pinned_field = client.enums.ServedAssetFieldTypeEnum[
+                entry["pinned_field"]
+            ]
         ad.responsive_search_ad.descriptions.append(asset)
 
     if changes.get("path1"):

--- a/src/adloop/server.py
+++ b/src/adloop/server.py
@@ -899,8 +899,8 @@ def update_campaign(
 @_safe
 def draft_responsive_search_ad(
     ad_group_id: str,
-    headlines: list[str],
-    descriptions: list[str],
+    headlines: list[str | dict],
+    descriptions: list[str | dict],
     final_url: str,
     customer_id: str = "",
     path1: str = "",
@@ -910,6 +910,19 @@ def draft_responsive_search_ad(
 
     Provide 3-15 headlines (max 30 chars each) and 2-4 descriptions (max 90 chars each).
     The preview shows exactly what will be created. Call confirm_and_apply to execute.
+
+    Each headline/description entry may be either:
+
+    - a plain string (unpinned), or
+    - a dict ``{"text": "...", "pinned_field": "HEADLINE_1"}`` (pinned).
+
+    Valid pin values:
+        headlines:    HEADLINE_1, HEADLINE_2, HEADLINE_3
+        descriptions: DESCRIPTION_1, DESCRIPTION_2
+
+    Google caps: at most 2 headlines per pin slot, at most 1 description per pin
+    slot. Mixed plain-string and dict entries are allowed within a single call
+    (e.g. brand pinned to HEADLINE_1, the rest unpinned).
     """
     from adloop.ads.write import draft_responsive_search_ad as _impl
 

--- a/tests/test_ads_write.py
+++ b/tests/test_ads_write.py
@@ -1187,3 +1187,154 @@ class TestConfirmAndApplyDryRunOverride:
 
         contents = log_path.read_text()
         assert "dry_run_success" in contents
+
+
+# ---------------------------------------------------------------------------
+# RSA pinning — _normalize_rsa_assets + _validate_rsa
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRsaAssets:
+    def test_accepts_plain_strings(self):
+        out = write._normalize_rsa_assets(["a", "b", "c"])
+        assert out == [
+            {"text": "a", "pinned_field": None},
+            {"text": "b", "pinned_field": None},
+            {"text": "c", "pinned_field": None},
+        ]
+
+    def test_accepts_dicts(self):
+        out = write._normalize_rsa_assets(
+            [
+                {"text": "Brand", "pinned_field": "HEADLINE_1"},
+                {"text": "Phone", "pinned_field": "HEADLINE_2"},
+            ]
+        )
+        assert out[0] == {"text": "Brand", "pinned_field": "HEADLINE_1"}
+        assert out[1] == {"text": "Phone", "pinned_field": "HEADLINE_2"}
+
+    def test_accepts_mixed(self):
+        out = write._normalize_rsa_assets(
+            [
+                {"text": "Brand", "pinned_field": "HEADLINE_1"},
+                "Free shipping",
+                "Same-day quotes",
+            ]
+        )
+        assert out[0]["pinned_field"] == "HEADLINE_1"
+        assert out[1] == {"text": "Free shipping", "pinned_field": None}
+        assert out[2] == {"text": "Same-day quotes", "pinned_field": None}
+
+    def test_dict_without_pin_defaults_to_none(self):
+        out = write._normalize_rsa_assets([{"text": "Hello"}])
+        assert out == [{"text": "Hello", "pinned_field": None}]
+
+    def test_rejects_non_str_non_dict(self):
+        with pytest.raises(ValueError, match="must be str or dict"):
+            write._normalize_rsa_assets([123])
+
+
+class TestValidateRsaPinning:
+    @staticmethod
+    def _hs(*items):
+        return write._normalize_rsa_assets(list(items))
+
+    @staticmethod
+    def _ds(*items):
+        return write._normalize_rsa_assets(list(items))
+
+    def test_canonical_3_pin_pattern_passes(self):
+        errs = write._validate_rsa(
+            "123",
+            self._hs(
+                {"text": "SandBagsToGo", "pinned_field": "HEADLINE_1"},
+                {"text": "866-550-2247", "pinned_field": "HEADLINE_2"},
+                "Free shipping",
+                "Same-day quotes",
+            ),
+            self._ds(
+                {"text": "Trusted by FEMA & Caltrans", "pinned_field": "DESCRIPTION_1"},
+                "Quick quotes, same-day shipping, USA-wide.",
+            ),
+            "https://sandbagstogo.com/",
+        )
+        assert errs == []
+
+    def test_rejects_invalid_headline_pin(self):
+        errs = write._validate_rsa(
+            "123",
+            self._hs({"text": "Brand", "pinned_field": "HEADLINE_99"}, "x", "y"),
+            self._ds("desc one", "desc two"),
+            "https://example.com/",
+        )
+        assert any("HEADLINE_99" in e for e in errs)
+
+    def test_rejects_invalid_description_pin(self):
+        errs = write._validate_rsa(
+            "123",
+            self._hs("a", "b", "c"),
+            self._ds(
+                {"text": "d1", "pinned_field": "DESCRIPTION_5"}, "d2"
+            ),
+            "https://example.com/",
+        )
+        assert any("DESCRIPTION_5" in e for e in errs)
+
+    def test_rejects_three_headlines_pinned_to_same_slot(self):
+        errs = write._validate_rsa(
+            "123",
+            self._hs(
+                {"text": "Brand A", "pinned_field": "HEADLINE_1"},
+                {"text": "Brand B", "pinned_field": "HEADLINE_1"},
+                {"text": "Brand C", "pinned_field": "HEADLINE_1"},
+            ),
+            self._ds("d1", "d2"),
+            "https://example.com/",
+        )
+        assert any("At most 2 headlines may pin to HEADLINE_1" in e for e in errs)
+
+    def test_rejects_two_descriptions_pinned_to_same_slot(self):
+        errs = write._validate_rsa(
+            "123",
+            self._hs("a", "b", "c"),
+            self._ds(
+                {"text": "d1", "pinned_field": "DESCRIPTION_1"},
+                {"text": "d2", "pinned_field": "DESCRIPTION_1"},
+            ),
+            "https://example.com/",
+        )
+        assert any(
+            "At most 1 description may pin to DESCRIPTION_1" in e for e in errs
+        )
+
+    def test_two_headlines_pinned_to_same_slot_is_allowed(self):
+        # Google permits up to 2 per pin slot
+        errs = write._validate_rsa(
+            "123",
+            self._hs(
+                {"text": "Brand A", "pinned_field": "HEADLINE_1"},
+                {"text": "Brand B", "pinned_field": "HEADLINE_1"},
+                "x",
+            ),
+            self._ds("d1", "d2"),
+            "https://example.com/",
+        )
+        assert errs == []
+
+    def test_length_check_still_enforced_on_dict_entries(self):
+        errs = write._validate_rsa(
+            "123",
+            self._hs({"text": "a" * 31, "pinned_field": "HEADLINE_1"}, "b", "c"),
+            self._ds("d1", "d2"),
+            "https://example.com/",
+        )
+        assert any("exceeds 30 chars" in e for e in errs)
+
+    def test_description_length_check_still_enforced_on_dict_entries(self):
+        errs = write._validate_rsa(
+            "123",
+            self._hs("a", "b", "c"),
+            self._ds({"text": "d" * 91, "pinned_field": "DESCRIPTION_1"}, "d2"),
+            "https://example.com/",
+        )
+        assert any("exceeds 90 chars" in e for e in errs)


### PR DESCRIPTION
## Summary

Adds optional `pinned_field` support per-headline and per-description in `draft_responsive_search_ad`. Currently the tool always creates unpinned RSA assets, which forces callers to drop into `google-ads-python` directly when they need brand-safety or compliance pins (e.g. company name in `HEADLINE_1`, phone number in `HEADLINE_2`).

## Why

Pinning is a routine RSA pattern — most accounts use at least one pinned headline (brand or phone) to guarantee it surfaces in every served ad. Without `pinned_field` exposed in the MCP layer, the only options are (a) leave all headlines unpinned and accept Google's auto-rotation, or (b) bypass adloop entirely for ad creation. (a) is a meaningful brand-control loss; (b) defeats the purpose of the safety layer.

## Design

**Backward compatible.** `headlines: list[str]` continues to work. The new shape is `list[str | dict]` where dict entries look like `{"text": "Brand", "pinned_field": "HEADLINE_1"}`. The two shapes can be mixed within a single call:

```python
draft_responsive_search_ad(
    headlines=[
        {"text": "Brand Name", "pinned_field": "HEADLINE_1"},
        {"text": "866-550-2247", "pinned_field": "HEADLINE_2"},
        "Free shipping",
        "Same-day quotes",
        # ...
    ],
    descriptions=[
        {"text": "Trusted by FEMA", "pinned_field": "DESCRIPTION_1"},
        "Quick quotes, USA-wide.",
    ],
    ...
)
```

A new `_normalize_rsa_assets()` helper converts plain strings to `{text, pinned_field: None}` so downstream code only deals with one shape.

## Validation

`_validate_rsa` now enforces Google's caps:

- Pin values must be in `{HEADLINE_1, HEADLINE_2, HEADLINE_3}` for headlines, `{DESCRIPTION_1, DESCRIPTION_2}` for descriptions.
- At most **2 headlines** pinned to the same `HEADLINE_N` slot.
- At most **1 description** pinned to the same `DESCRIPTION_N` slot.

Length checks (>30 char headlines, >90 char descriptions) continue to apply, now reading `entry["text"]` instead of the raw string.

## Apply path

`_apply_create_rsa` sets `asset.pinned_field = client.enums.ServedAssetFieldTypeEnum[entry["pinned_field"]]` when the entry has a non-null pin. Unpinned entries skip the assignment, preserving today's behavior.

## Tests

13 new unit tests under two classes in `tests/test_ads_write.py`:

- `TestNormalizeRsaAssets` — accepts plain strings, dicts, mixed; defaults missing pin to `None`; rejects non-str/non-dict.
- `TestValidateRsaPinning` — canonical 3-pin pattern passes; invalid pin names rejected; 3-on-same-slot rejected for headlines; 2-on-same-slot rejected for descriptions; 2-on-same-slot allowed for headlines (Google permits up to 2); length checks still enforced on dict entries.

`uv run pytest` — all 155 tests pass (13 new + 142 existing).

## Out of scope

- This PR only touches the create path (`_apply_create_rsa`). If an RSA update path lands later, it would need the same `pinned_field` handling.
- No change to `confirm_and_apply` — the `ChangePlan.changes` dict now stores normalized dict entries, which the apply function consumes directly.

## Test plan

- [x] `uv run pytest` — 155 pass
- [x] Existing string-only callers continue to work (covered by unchanged tests)
- [ ] Live-API smoke test with a pinned RSA against a paused ad group (recommended before merge if a maintainer-side test account is available)
